### PR TITLE
Add Claude Code plugin marketplace for skill distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,11 +2,11 @@
   "name": "pm-skills",
   "owner": {
     "name": "Dean Peters",
-    "email": "dean@productside.com"
+    "email": "dean.peters@productside.com"
   },
   "metadata": {
     "description": "46 battle-tested product management skills for Claude Code — discovery, strategy, finance, career, and more.",
-    "version": "0.7.0"
+    "version": "0.75.0"
   },
   "plugins": [
     {
@@ -14,7 +14,12 @@
       "source": "./skills/company-research",
       "description": "Create a company research brief with executive quotes, product strategy, and org context.",
       "category": "discovery",
-      "tags": ["pm", "research", "competitive-analysis", "interviews"],
+      "tags": [
+        "pm",
+        "research",
+        "competitive-analysis",
+        "interviews"
+      ],
       "strict": false
     },
     {
@@ -22,7 +27,12 @@
       "source": "./skills/customer-journey-map",
       "description": "Create a customer journey map across stages, touchpoints, actions, emotions, and metrics.",
       "category": "discovery",
-      "tags": ["pm", "journey-map", "ux", "customer-experience"],
+      "tags": [
+        "pm",
+        "journey-map",
+        "ux",
+        "customer-experience"
+      ],
       "strict": false
     },
     {
@@ -30,7 +40,12 @@
       "source": "./skills/customer-journey-mapping-workshop",
       "description": "Run a customer journey mapping workshop with adaptive questions and outputs.",
       "category": "discovery",
-      "tags": ["pm", "journey-map", "workshop", "facilitation"],
+      "tags": [
+        "pm",
+        "journey-map",
+        "workshop",
+        "facilitation"
+      ],
       "strict": false
     },
     {
@@ -38,7 +53,12 @@
       "source": "./skills/discovery-interview-prep",
       "description": "Plan customer discovery interviews with the right goal, segment, constraints, and method.",
       "category": "discovery",
-      "tags": ["pm", "discovery", "interviews", "customer-research"],
+      "tags": [
+        "pm",
+        "discovery",
+        "interviews",
+        "customer-research"
+      ],
       "strict": false
     },
     {
@@ -46,7 +66,12 @@
       "source": "./skills/discovery-process",
       "description": "Run a full discovery cycle from problem hypothesis to validated solution.",
       "category": "discovery",
-      "tags": ["pm", "discovery", "validation", "workflow"],
+      "tags": [
+        "pm",
+        "discovery",
+        "validation",
+        "workflow"
+      ],
       "strict": false
     },
     {
@@ -54,7 +79,12 @@
       "source": "./skills/jobs-to-be-done",
       "description": "Uncover customer jobs, pains, and gains in a structured JTBD format.",
       "category": "discovery",
-      "tags": ["pm", "jtbd", "customer-needs", "discovery"],
+      "tags": [
+        "pm",
+        "jtbd",
+        "customer-needs",
+        "discovery"
+      ],
       "strict": false
     },
     {
@@ -62,7 +92,12 @@
       "source": "./skills/lean-ux-canvas",
       "description": "Guide teams through Lean UX Canvas v2 to frame problems and surface assumptions.",
       "category": "discovery",
-      "tags": ["pm", "lean-ux", "assumptions", "experimentation"],
+      "tags": [
+        "pm",
+        "lean-ux",
+        "assumptions",
+        "experimentation"
+      ],
       "strict": false
     },
     {
@@ -70,7 +105,12 @@
       "source": "./skills/opportunity-solution-tree",
       "description": "Build an Opportunity Solution Tree from outcomes to opportunities, solutions, and tests.",
       "category": "discovery",
-      "tags": ["pm", "ost", "teresa-torres", "continuous-discovery"],
+      "tags": [
+        "pm",
+        "ost",
+        "teresa-torres",
+        "continuous-discovery"
+      ],
       "strict": false
     },
     {
@@ -78,7 +118,12 @@
       "source": "./skills/problem-framing-canvas",
       "description": "Guide teams through MITRE's Problem Framing Canvas for clearer problem statements.",
       "category": "discovery",
-      "tags": ["pm", "problem-framing", "mitre", "workshop"],
+      "tags": [
+        "pm",
+        "problem-framing",
+        "mitre",
+        "workshop"
+      ],
       "strict": false
     },
     {
@@ -86,7 +131,12 @@
       "source": "./skills/problem-statement",
       "description": "Write a user-centered problem statement with who, what, why, and how it feels.",
       "category": "discovery",
-      "tags": ["pm", "problem-statement", "framing", "empathy"],
+      "tags": [
+        "pm",
+        "problem-statement",
+        "framing",
+        "empathy"
+      ],
       "strict": false
     },
     {
@@ -94,7 +144,12 @@
       "source": "./skills/proto-persona",
       "description": "Create a proto-persona from current research, market signals, and team knowledge.",
       "category": "discovery",
-      "tags": ["pm", "persona", "user-research", "assumptions"],
+      "tags": [
+        "pm",
+        "persona",
+        "user-research",
+        "assumptions"
+      ],
       "strict": false
     },
     {
@@ -102,7 +157,12 @@
       "source": "./skills/pestel-analysis",
       "description": "Analyze political, economic, social, technological, environmental, and legal forces.",
       "category": "strategy",
-      "tags": ["pm", "pestel", "macro-environment", "strategy"],
+      "tags": [
+        "pm",
+        "pestel",
+        "macro-environment",
+        "strategy"
+      ],
       "strict": false
     },
     {
@@ -110,7 +170,12 @@
       "source": "./skills/positioning-statement",
       "description": "Create a Geoffrey Moore-style positioning statement for your product.",
       "category": "strategy",
-      "tags": ["pm", "positioning", "geoffrey-moore", "messaging"],
+      "tags": [
+        "pm",
+        "positioning",
+        "geoffrey-moore",
+        "messaging"
+      ],
       "strict": false
     },
     {
@@ -118,7 +183,12 @@
       "source": "./skills/positioning-workshop",
       "description": "Run a positioning workshop to surface target customer, need, category, and differentiation.",
       "category": "strategy",
-      "tags": ["pm", "positioning", "workshop", "messaging"],
+      "tags": [
+        "pm",
+        "positioning",
+        "workshop",
+        "messaging"
+      ],
       "strict": false
     },
     {
@@ -126,7 +196,12 @@
       "source": "./skills/prd-development",
       "description": "Build a structured PRD connecting problem, users, solution, and success criteria.",
       "category": "strategy",
-      "tags": ["pm", "prd", "requirements", "workflow"],
+      "tags": [
+        "pm",
+        "prd",
+        "requirements",
+        "workflow"
+      ],
       "strict": false
     },
     {
@@ -134,7 +209,12 @@
       "source": "./skills/press-release",
       "description": "Write an Amazon-style press release that defines customer value before building.",
       "category": "strategy",
-      "tags": ["pm", "press-release", "amazon", "working-backwards"],
+      "tags": [
+        "pm",
+        "press-release",
+        "amazon",
+        "working-backwards"
+      ],
       "strict": false
     },
     {
@@ -142,7 +222,12 @@
       "source": "./skills/prioritization-advisor",
       "description": "Choose a prioritization framework based on stage, team context, and stakeholder needs.",
       "category": "strategy",
-      "tags": ["pm", "prioritization", "rice", "scoring"],
+      "tags": [
+        "pm",
+        "prioritization",
+        "rice",
+        "scoring"
+      ],
       "strict": false
     },
     {
@@ -150,7 +235,12 @@
       "source": "./skills/product-strategy-session",
       "description": "Run an end-to-end product strategy session across positioning, discovery, and roadmap.",
       "category": "strategy",
-      "tags": ["pm", "strategy", "workshop", "workflow"],
+      "tags": [
+        "pm",
+        "strategy",
+        "workshop",
+        "workflow"
+      ],
       "strict": false
     },
     {
@@ -158,7 +248,12 @@
       "source": "./skills/roadmap-planning",
       "description": "Plan a strategic roadmap across prioritization, epics, stakeholders, and sequencing.",
       "category": "strategy",
-      "tags": ["pm", "roadmap", "planning", "workflow"],
+      "tags": [
+        "pm",
+        "roadmap",
+        "planning",
+        "workflow"
+      ],
       "strict": false
     },
     {
@@ -166,7 +261,12 @@
       "source": "./skills/tam-sam-som-calculator",
       "description": "Calculate TAM, SAM, and SOM with explicit assumptions, methods, and caveats.",
       "category": "strategy",
-      "tags": ["pm", "market-sizing", "tam", "business-case"],
+      "tags": [
+        "pm",
+        "market-sizing",
+        "tam",
+        "business-case"
+      ],
       "strict": false
     },
     {
@@ -174,7 +274,12 @@
       "source": "./skills/eol-message",
       "description": "Write a clear, empathetic EOL announcement with rationale and next steps.",
       "category": "strategy",
-      "tags": ["pm", "eol", "communication", "sunset"],
+      "tags": [
+        "pm",
+        "eol",
+        "communication",
+        "sunset"
+      ],
       "strict": false
     },
     {
@@ -182,7 +287,12 @@
       "source": "./skills/epic-breakdown-advisor",
       "description": "Break down epics into user stories with Humanizing Work split patterns.",
       "category": "delivery",
-      "tags": ["pm", "epics", "splitting", "backlog"],
+      "tags": [
+        "pm",
+        "epics",
+        "splitting",
+        "backlog"
+      ],
       "strict": false
     },
     {
@@ -190,7 +300,12 @@
       "source": "./skills/epic-hypothesis",
       "description": "Frame an epic as a testable hypothesis with target user, outcome, and validation.",
       "category": "delivery",
-      "tags": ["pm", "epics", "hypothesis", "validation"],
+      "tags": [
+        "pm",
+        "epics",
+        "hypothesis",
+        "validation"
+      ],
       "strict": false
     },
     {
@@ -198,7 +313,12 @@
       "source": "./skills/storyboard",
       "description": "Create a six-frame storyboard showing a user's journey from problem to solution.",
       "category": "delivery",
-      "tags": ["pm", "storyboard", "narrative", "ux"],
+      "tags": [
+        "pm",
+        "storyboard",
+        "narrative",
+        "ux"
+      ],
       "strict": false
     },
     {
@@ -206,7 +326,12 @@
       "source": "./skills/user-story",
       "description": "Create user stories with Mike Cohn format and Gherkin acceptance criteria.",
       "category": "delivery",
-      "tags": ["pm", "user-stories", "acceptance-criteria", "gherkin"],
+      "tags": [
+        "pm",
+        "user-stories",
+        "acceptance-criteria",
+        "gherkin"
+      ],
       "strict": false
     },
     {
@@ -214,7 +339,12 @@
       "source": "./skills/user-story-mapping",
       "description": "Create a user story map with activities, steps, tasks, and release slices.",
       "category": "delivery",
-      "tags": ["pm", "story-mapping", "backlog", "mvp"],
+      "tags": [
+        "pm",
+        "story-mapping",
+        "backlog",
+        "mvp"
+      ],
       "strict": false
     },
     {
@@ -222,7 +352,12 @@
       "source": "./skills/user-story-mapping-workshop",
       "description": "Run a user story mapping workshop with adaptive questions and structured output.",
       "category": "delivery",
-      "tags": ["pm", "story-mapping", "workshop", "facilitation"],
+      "tags": [
+        "pm",
+        "story-mapping",
+        "workshop",
+        "facilitation"
+      ],
       "strict": false
     },
     {
@@ -230,7 +365,12 @@
       "source": "./skills/user-story-splitting",
       "description": "Break a large story into smaller deliverable stories using proven split patterns.",
       "category": "delivery",
-      "tags": ["pm", "splitting", "user-stories", "backlog"],
+      "tags": [
+        "pm",
+        "splitting",
+        "user-stories",
+        "backlog"
+      ],
       "strict": false
     },
     {
@@ -238,7 +378,13 @@
       "source": "./skills/acquisition-channel-advisor",
       "description": "Evaluate acquisition channels using unit economics, customer quality, and scalability.",
       "category": "finance",
-      "tags": ["pm", "finance", "acquisition", "unit-economics", "growth"],
+      "tags": [
+        "pm",
+        "finance",
+        "acquisition",
+        "unit-economics",
+        "growth"
+      ],
       "strict": false
     },
     {
@@ -246,7 +392,13 @@
       "source": "./skills/business-health-diagnostic",
       "description": "Diagnose SaaS business health across growth, retention, efficiency, and capital.",
       "category": "finance",
-      "tags": ["pm", "finance", "saas", "metrics", "diagnostic"],
+      "tags": [
+        "pm",
+        "finance",
+        "saas",
+        "metrics",
+        "diagnostic"
+      ],
       "strict": false
     },
     {
@@ -254,7 +406,13 @@
       "source": "./skills/feature-investment-advisor",
       "description": "Evaluate feature investments using revenue impact, cost structure, ROI, and strategy.",
       "category": "finance",
-      "tags": ["pm", "finance", "roi", "investment", "feature"],
+      "tags": [
+        "pm",
+        "finance",
+        "roi",
+        "investment",
+        "feature"
+      ],
       "strict": false
     },
     {
@@ -262,7 +420,13 @@
       "source": "./skills/finance-based-pricing-advisor",
       "description": "Evaluate pricing changes using ARPU, conversion, churn risk, NRR, and payback.",
       "category": "finance",
-      "tags": ["pm", "finance", "pricing", "arpu", "churn"],
+      "tags": [
+        "pm",
+        "finance",
+        "pricing",
+        "arpu",
+        "churn"
+      ],
       "strict": false
     },
     {
@@ -270,7 +434,13 @@
       "source": "./skills/finance-metrics-quickref",
       "description": "Look up SaaS finance metrics, formulas, and benchmarks fast.",
       "category": "finance",
-      "tags": ["pm", "finance", "metrics", "reference", "saas"],
+      "tags": [
+        "pm",
+        "finance",
+        "metrics",
+        "reference",
+        "saas"
+      ],
       "strict": false
     },
     {
@@ -278,7 +448,13 @@
       "source": "./skills/saas-economics-efficiency-metrics",
       "description": "Evaluate SaaS unit economics and capital efficiency for scaling decisions.",
       "category": "finance",
-      "tags": ["pm", "finance", "unit-economics", "efficiency", "saas"],
+      "tags": [
+        "pm",
+        "finance",
+        "unit-economics",
+        "efficiency",
+        "saas"
+      ],
       "strict": false
     },
     {
@@ -286,7 +462,13 @@
       "source": "./skills/saas-revenue-growth-metrics",
       "description": "Calculate SaaS revenue, retention, and growth metrics for momentum diagnosis.",
       "category": "finance",
-      "tags": ["pm", "finance", "revenue", "retention", "growth"],
+      "tags": [
+        "pm",
+        "finance",
+        "revenue",
+        "retention",
+        "growth"
+      ],
       "strict": false
     },
     {
@@ -294,7 +476,13 @@
       "source": "./skills/altitude-horizon-framework",
       "description": "Understand the PM-to-Director transition through altitude and horizon thinking.",
       "category": "career",
-      "tags": ["pm", "career", "director", "leadership", "transition"],
+      "tags": [
+        "pm",
+        "career",
+        "director",
+        "leadership",
+        "transition"
+      ],
       "strict": false
     },
     {
@@ -302,7 +490,13 @@
       "source": "./skills/director-readiness-advisor",
       "description": "Guide the PM-to-Director transition across preparing, interviewing, and landing.",
       "category": "career",
-      "tags": ["pm", "career", "director", "coaching", "transition"],
+      "tags": [
+        "pm",
+        "career",
+        "director",
+        "coaching",
+        "transition"
+      ],
       "strict": false
     },
     {
@@ -310,7 +504,14 @@
       "source": "./skills/executive-onboarding-playbook",
       "description": "Plan a VP or CPO 30-60-90 day diagnostic onboarding path.",
       "category": "career",
-      "tags": ["pm", "career", "executive", "onboarding", "vp", "cpo"],
+      "tags": [
+        "pm",
+        "career",
+        "executive",
+        "onboarding",
+        "vp",
+        "cpo"
+      ],
       "strict": false
     },
     {
@@ -318,7 +519,14 @@
       "source": "./skills/vp-cpo-readiness-advisor",
       "description": "Guide the transition to VP or CPO across preparing, interviewing, and recalibrating.",
       "category": "career",
-      "tags": ["pm", "career", "vp", "cpo", "executive", "coaching"],
+      "tags": [
+        "pm",
+        "career",
+        "vp",
+        "cpo",
+        "executive",
+        "coaching"
+      ],
       "strict": false
     },
     {
@@ -326,7 +534,13 @@
       "source": "./skills/ai-shaped-readiness-advisor",
       "description": "Assess whether your product work is AI-first or AI-shaped across 5 competencies.",
       "category": "ai",
-      "tags": ["pm", "ai", "readiness", "assessment", "competencies"],
+      "tags": [
+        "pm",
+        "ai",
+        "readiness",
+        "assessment",
+        "competencies"
+      ],
       "strict": false
     },
     {
@@ -334,7 +548,13 @@
       "source": "./skills/context-engineering-advisor",
       "description": "Diagnose context stuffing vs. context engineering in AI workflows.",
       "category": "ai",
-      "tags": ["pm", "ai", "context-engineering", "llm", "prompting"],
+      "tags": [
+        "pm",
+        "ai",
+        "context-engineering",
+        "llm",
+        "prompting"
+      ],
       "strict": false
     },
     {
@@ -342,7 +562,12 @@
       "source": "./skills/pol-probe",
       "description": "Define a Proof of Life probe to test a risky hypothesis cheaply.",
       "category": "ai",
-      "tags": ["pm", "validation", "proof-of-life", "experimentation"],
+      "tags": [
+        "pm",
+        "validation",
+        "proof-of-life",
+        "experimentation"
+      ],
       "strict": false
     },
     {
@@ -350,7 +575,12 @@
       "source": "./skills/pol-probe-advisor",
       "description": "Select the right Proof of Life probe type based on hypothesis, risk, and resources.",
       "category": "ai",
-      "tags": ["pm", "validation", "proof-of-life", "advisor"],
+      "tags": [
+        "pm",
+        "validation",
+        "proof-of-life",
+        "advisor"
+      ],
       "strict": false
     },
     {
@@ -358,7 +588,13 @@
       "source": "./skills/recommendation-canvas",
       "description": "Evaluate an AI product idea across outcomes, hypotheses, risks, and positioning.",
       "category": "ai",
-      "tags": ["pm", "ai", "evaluation", "canvas", "recommendation"],
+      "tags": [
+        "pm",
+        "ai",
+        "evaluation",
+        "canvas",
+        "recommendation"
+      ],
       "strict": false
     },
     {
@@ -366,7 +602,12 @@
       "source": "./skills/workshop-facilitation",
       "description": "Facilitate workshop sessions with consistent pacing, options, and progress tracking.",
       "category": "meta",
-      "tags": ["pm", "facilitation", "workshop", "interactive"],
+      "tags": [
+        "pm",
+        "facilitation",
+        "workshop",
+        "interactive"
+      ],
       "strict": false
     },
     {
@@ -374,7 +615,12 @@
       "source": "./skills/skill-authoring-workflow",
       "description": "Turn raw PM content into a compliant, publish-ready skill.",
       "category": "meta",
-      "tags": ["pm", "skill-authoring", "contributor", "workflow"],
+      "tags": [
+        "pm",
+        "skill-authoring",
+        "contributor",
+        "workflow"
+      ],
       "strict": false
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,381 @@
+{
+  "name": "pm-skills",
+  "owner": {
+    "name": "Dean Peters",
+    "email": "dean@productside.com"
+  },
+  "metadata": {
+    "description": "46 battle-tested product management skills for Claude Code — discovery, strategy, finance, career, and more.",
+    "version": "0.7.0"
+  },
+  "plugins": [
+    {
+      "name": "company-research",
+      "source": "./skills/company-research",
+      "description": "Create a company research brief with executive quotes, product strategy, and org context.",
+      "category": "discovery",
+      "tags": ["pm", "research", "competitive-analysis", "interviews"],
+      "strict": false
+    },
+    {
+      "name": "customer-journey-map",
+      "source": "./skills/customer-journey-map",
+      "description": "Create a customer journey map across stages, touchpoints, actions, emotions, and metrics.",
+      "category": "discovery",
+      "tags": ["pm", "journey-map", "ux", "customer-experience"],
+      "strict": false
+    },
+    {
+      "name": "customer-journey-mapping-workshop",
+      "source": "./skills/customer-journey-mapping-workshop",
+      "description": "Run a customer journey mapping workshop with adaptive questions and outputs.",
+      "category": "discovery",
+      "tags": ["pm", "journey-map", "workshop", "facilitation"],
+      "strict": false
+    },
+    {
+      "name": "discovery-interview-prep",
+      "source": "./skills/discovery-interview-prep",
+      "description": "Plan customer discovery interviews with the right goal, segment, constraints, and method.",
+      "category": "discovery",
+      "tags": ["pm", "discovery", "interviews", "customer-research"],
+      "strict": false
+    },
+    {
+      "name": "discovery-process",
+      "source": "./skills/discovery-process",
+      "description": "Run a full discovery cycle from problem hypothesis to validated solution.",
+      "category": "discovery",
+      "tags": ["pm", "discovery", "validation", "workflow"],
+      "strict": false
+    },
+    {
+      "name": "jobs-to-be-done",
+      "source": "./skills/jobs-to-be-done",
+      "description": "Uncover customer jobs, pains, and gains in a structured JTBD format.",
+      "category": "discovery",
+      "tags": ["pm", "jtbd", "customer-needs", "discovery"],
+      "strict": false
+    },
+    {
+      "name": "lean-ux-canvas",
+      "source": "./skills/lean-ux-canvas",
+      "description": "Guide teams through Lean UX Canvas v2 to frame problems and surface assumptions.",
+      "category": "discovery",
+      "tags": ["pm", "lean-ux", "assumptions", "experimentation"],
+      "strict": false
+    },
+    {
+      "name": "opportunity-solution-tree",
+      "source": "./skills/opportunity-solution-tree",
+      "description": "Build an Opportunity Solution Tree from outcomes to opportunities, solutions, and tests.",
+      "category": "discovery",
+      "tags": ["pm", "ost", "teresa-torres", "continuous-discovery"],
+      "strict": false
+    },
+    {
+      "name": "problem-framing-canvas",
+      "source": "./skills/problem-framing-canvas",
+      "description": "Guide teams through MITRE's Problem Framing Canvas for clearer problem statements.",
+      "category": "discovery",
+      "tags": ["pm", "problem-framing", "mitre", "workshop"],
+      "strict": false
+    },
+    {
+      "name": "problem-statement",
+      "source": "./skills/problem-statement",
+      "description": "Write a user-centered problem statement with who, what, why, and how it feels.",
+      "category": "discovery",
+      "tags": ["pm", "problem-statement", "framing", "empathy"],
+      "strict": false
+    },
+    {
+      "name": "proto-persona",
+      "source": "./skills/proto-persona",
+      "description": "Create a proto-persona from current research, market signals, and team knowledge.",
+      "category": "discovery",
+      "tags": ["pm", "persona", "user-research", "assumptions"],
+      "strict": false
+    },
+    {
+      "name": "pestel-analysis",
+      "source": "./skills/pestel-analysis",
+      "description": "Analyze political, economic, social, technological, environmental, and legal forces.",
+      "category": "strategy",
+      "tags": ["pm", "pestel", "macro-environment", "strategy"],
+      "strict": false
+    },
+    {
+      "name": "positioning-statement",
+      "source": "./skills/positioning-statement",
+      "description": "Create a Geoffrey Moore-style positioning statement for your product.",
+      "category": "strategy",
+      "tags": ["pm", "positioning", "geoffrey-moore", "messaging"],
+      "strict": false
+    },
+    {
+      "name": "positioning-workshop",
+      "source": "./skills/positioning-workshop",
+      "description": "Run a positioning workshop to surface target customer, need, category, and differentiation.",
+      "category": "strategy",
+      "tags": ["pm", "positioning", "workshop", "messaging"],
+      "strict": false
+    },
+    {
+      "name": "prd-development",
+      "source": "./skills/prd-development",
+      "description": "Build a structured PRD connecting problem, users, solution, and success criteria.",
+      "category": "strategy",
+      "tags": ["pm", "prd", "requirements", "workflow"],
+      "strict": false
+    },
+    {
+      "name": "press-release",
+      "source": "./skills/press-release",
+      "description": "Write an Amazon-style press release that defines customer value before building.",
+      "category": "strategy",
+      "tags": ["pm", "press-release", "amazon", "working-backwards"],
+      "strict": false
+    },
+    {
+      "name": "prioritization-advisor",
+      "source": "./skills/prioritization-advisor",
+      "description": "Choose a prioritization framework based on stage, team context, and stakeholder needs.",
+      "category": "strategy",
+      "tags": ["pm", "prioritization", "rice", "scoring"],
+      "strict": false
+    },
+    {
+      "name": "product-strategy-session",
+      "source": "./skills/product-strategy-session",
+      "description": "Run an end-to-end product strategy session across positioning, discovery, and roadmap.",
+      "category": "strategy",
+      "tags": ["pm", "strategy", "workshop", "workflow"],
+      "strict": false
+    },
+    {
+      "name": "roadmap-planning",
+      "source": "./skills/roadmap-planning",
+      "description": "Plan a strategic roadmap across prioritization, epics, stakeholders, and sequencing.",
+      "category": "strategy",
+      "tags": ["pm", "roadmap", "planning", "workflow"],
+      "strict": false
+    },
+    {
+      "name": "tam-sam-som-calculator",
+      "source": "./skills/tam-sam-som-calculator",
+      "description": "Calculate TAM, SAM, and SOM with explicit assumptions, methods, and caveats.",
+      "category": "strategy",
+      "tags": ["pm", "market-sizing", "tam", "business-case"],
+      "strict": false
+    },
+    {
+      "name": "eol-message",
+      "source": "./skills/eol-message",
+      "description": "Write a clear, empathetic EOL announcement with rationale and next steps.",
+      "category": "strategy",
+      "tags": ["pm", "eol", "communication", "sunset"],
+      "strict": false
+    },
+    {
+      "name": "epic-breakdown-advisor",
+      "source": "./skills/epic-breakdown-advisor",
+      "description": "Break down epics into user stories with Humanizing Work split patterns.",
+      "category": "delivery",
+      "tags": ["pm", "epics", "splitting", "backlog"],
+      "strict": false
+    },
+    {
+      "name": "epic-hypothesis",
+      "source": "./skills/epic-hypothesis",
+      "description": "Frame an epic as a testable hypothesis with target user, outcome, and validation.",
+      "category": "delivery",
+      "tags": ["pm", "epics", "hypothesis", "validation"],
+      "strict": false
+    },
+    {
+      "name": "storyboard",
+      "source": "./skills/storyboard",
+      "description": "Create a six-frame storyboard showing a user's journey from problem to solution.",
+      "category": "delivery",
+      "tags": ["pm", "storyboard", "narrative", "ux"],
+      "strict": false
+    },
+    {
+      "name": "user-story",
+      "source": "./skills/user-story",
+      "description": "Create user stories with Mike Cohn format and Gherkin acceptance criteria.",
+      "category": "delivery",
+      "tags": ["pm", "user-stories", "acceptance-criteria", "gherkin"],
+      "strict": false
+    },
+    {
+      "name": "user-story-mapping",
+      "source": "./skills/user-story-mapping",
+      "description": "Create a user story map with activities, steps, tasks, and release slices.",
+      "category": "delivery",
+      "tags": ["pm", "story-mapping", "backlog", "mvp"],
+      "strict": false
+    },
+    {
+      "name": "user-story-mapping-workshop",
+      "source": "./skills/user-story-mapping-workshop",
+      "description": "Run a user story mapping workshop with adaptive questions and structured output.",
+      "category": "delivery",
+      "tags": ["pm", "story-mapping", "workshop", "facilitation"],
+      "strict": false
+    },
+    {
+      "name": "user-story-splitting",
+      "source": "./skills/user-story-splitting",
+      "description": "Break a large story into smaller deliverable stories using proven split patterns.",
+      "category": "delivery",
+      "tags": ["pm", "splitting", "user-stories", "backlog"],
+      "strict": false
+    },
+    {
+      "name": "acquisition-channel-advisor",
+      "source": "./skills/acquisition-channel-advisor",
+      "description": "Evaluate acquisition channels using unit economics, customer quality, and scalability.",
+      "category": "finance",
+      "tags": ["pm", "finance", "acquisition", "unit-economics", "growth"],
+      "strict": false
+    },
+    {
+      "name": "business-health-diagnostic",
+      "source": "./skills/business-health-diagnostic",
+      "description": "Diagnose SaaS business health across growth, retention, efficiency, and capital.",
+      "category": "finance",
+      "tags": ["pm", "finance", "saas", "metrics", "diagnostic"],
+      "strict": false
+    },
+    {
+      "name": "feature-investment-advisor",
+      "source": "./skills/feature-investment-advisor",
+      "description": "Evaluate feature investments using revenue impact, cost structure, ROI, and strategy.",
+      "category": "finance",
+      "tags": ["pm", "finance", "roi", "investment", "feature"],
+      "strict": false
+    },
+    {
+      "name": "finance-based-pricing-advisor",
+      "source": "./skills/finance-based-pricing-advisor",
+      "description": "Evaluate pricing changes using ARPU, conversion, churn risk, NRR, and payback.",
+      "category": "finance",
+      "tags": ["pm", "finance", "pricing", "arpu", "churn"],
+      "strict": false
+    },
+    {
+      "name": "finance-metrics-quickref",
+      "source": "./skills/finance-metrics-quickref",
+      "description": "Look up SaaS finance metrics, formulas, and benchmarks fast.",
+      "category": "finance",
+      "tags": ["pm", "finance", "metrics", "reference", "saas"],
+      "strict": false
+    },
+    {
+      "name": "saas-economics-efficiency-metrics",
+      "source": "./skills/saas-economics-efficiency-metrics",
+      "description": "Evaluate SaaS unit economics and capital efficiency for scaling decisions.",
+      "category": "finance",
+      "tags": ["pm", "finance", "unit-economics", "efficiency", "saas"],
+      "strict": false
+    },
+    {
+      "name": "saas-revenue-growth-metrics",
+      "source": "./skills/saas-revenue-growth-metrics",
+      "description": "Calculate SaaS revenue, retention, and growth metrics for momentum diagnosis.",
+      "category": "finance",
+      "tags": ["pm", "finance", "revenue", "retention", "growth"],
+      "strict": false
+    },
+    {
+      "name": "altitude-horizon-framework",
+      "source": "./skills/altitude-horizon-framework",
+      "description": "Understand the PM-to-Director transition through altitude and horizon thinking.",
+      "category": "career",
+      "tags": ["pm", "career", "director", "leadership", "transition"],
+      "strict": false
+    },
+    {
+      "name": "director-readiness-advisor",
+      "source": "./skills/director-readiness-advisor",
+      "description": "Guide the PM-to-Director transition across preparing, interviewing, and landing.",
+      "category": "career",
+      "tags": ["pm", "career", "director", "coaching", "transition"],
+      "strict": false
+    },
+    {
+      "name": "executive-onboarding-playbook",
+      "source": "./skills/executive-onboarding-playbook",
+      "description": "Plan a VP or CPO 30-60-90 day diagnostic onboarding path.",
+      "category": "career",
+      "tags": ["pm", "career", "executive", "onboarding", "vp", "cpo"],
+      "strict": false
+    },
+    {
+      "name": "vp-cpo-readiness-advisor",
+      "source": "./skills/vp-cpo-readiness-advisor",
+      "description": "Guide the transition to VP or CPO across preparing, interviewing, and recalibrating.",
+      "category": "career",
+      "tags": ["pm", "career", "vp", "cpo", "executive", "coaching"],
+      "strict": false
+    },
+    {
+      "name": "ai-shaped-readiness-advisor",
+      "source": "./skills/ai-shaped-readiness-advisor",
+      "description": "Assess whether your product work is AI-first or AI-shaped across 5 competencies.",
+      "category": "ai",
+      "tags": ["pm", "ai", "readiness", "assessment", "competencies"],
+      "strict": false
+    },
+    {
+      "name": "context-engineering-advisor",
+      "source": "./skills/context-engineering-advisor",
+      "description": "Diagnose context stuffing vs. context engineering in AI workflows.",
+      "category": "ai",
+      "tags": ["pm", "ai", "context-engineering", "llm", "prompting"],
+      "strict": false
+    },
+    {
+      "name": "pol-probe",
+      "source": "./skills/pol-probe",
+      "description": "Define a Proof of Life probe to test a risky hypothesis cheaply.",
+      "category": "ai",
+      "tags": ["pm", "validation", "proof-of-life", "experimentation"],
+      "strict": false
+    },
+    {
+      "name": "pol-probe-advisor",
+      "source": "./skills/pol-probe-advisor",
+      "description": "Select the right Proof of Life probe type based on hypothesis, risk, and resources.",
+      "category": "ai",
+      "tags": ["pm", "validation", "proof-of-life", "advisor"],
+      "strict": false
+    },
+    {
+      "name": "recommendation-canvas",
+      "source": "./skills/recommendation-canvas",
+      "description": "Evaluate an AI product idea across outcomes, hypotheses, risks, and positioning.",
+      "category": "ai",
+      "tags": ["pm", "ai", "evaluation", "canvas", "recommendation"],
+      "strict": false
+    },
+    {
+      "name": "workshop-facilitation",
+      "source": "./skills/workshop-facilitation",
+      "description": "Facilitate workshop sessions with consistent pacing, options, and progress tracking.",
+      "category": "meta",
+      "tags": ["pm", "facilitation", "workshop", "interactive"],
+      "strict": false
+    },
+    {
+      "name": "skill-authoring-workflow",
+      "source": "./skills/skill-authoring-workflow",
+      "description": "Turn raw PM content into a compliant, publish-ready skill.",
+      "category": "meta",
+      "tags": ["pm", "skill-authoring", "contributor", "workflow"],
+      "strict": false
+    }
+  ]
+}


### PR DESCRIPTION
Hey Dean! Long time no see — hope you've been well.

I've been following the PM Skills repo and really dig what you've built here. I noticed these skills map perfectly to Claude Code's new [plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) system, so I put together a `marketplace.json` to make them installable directly from the CLI.

## What this does

Adds a single file (`.claude-plugin/marketplace.json`) that registers all 46 skills as installable plugins. No changes to existing files, no new directories — just a catalog that points at the existing `skills/` tree.

Once merged, users can install skills like:

```bash
# Add the marketplace
/plugin marketplace add deanpeters/Product-Manager-Skills

# Install individual skills by name
/plugin install jobs-to-be-done@pm-skills
/plugin install prd-development@pm-skills
/plugin install business-health-diagnostic@pm-skills
```

## Details

- Each skill is its own plugin entry with `category` and `tags` for discovery
- Categories match the existing groupings: `discovery`, `strategy`, `delivery`, `finance`, `career`, `ai`, `meta`
- Uses `strict: false` so the marketplace entry is the full definition — no extra `plugin.json` files needed in each skill directory
- License field set to `CC-BY-NC-SA-4.0` on all entries
- Zero changes to existing skills, scripts, or docs

## How it works

Claude Code's plugin system supports [relative path sources](https://code.claude.com/docs/en/plugin-marketplaces#relative-paths), so each plugin entry just points at `./skills/skill-name`. When a user installs a skill, Claude Code copies that directory into its local plugin cache. The existing `SKILL.md` files are already in the right format.

Let me know what you think — happy to adjust groupings, tags, or anything else.