### PR TITLE
feat: improve skill scores across 46 Product Manager Skills

### DIFF
--- a/skills/acquisition-channel-advisor/SKILL.md
+++ b/skills/acquisition-channel-advisor/SKILL.md
@@ -19,8 +19,6 @@ scenarios:
 
 Guide product managers through evaluating whether to scale, test, or kill an acquisition channel based on unit economics (CAC, LTV, payback), customer quality (retention, NRR), and scalability (magic number, volume potential). Use this to make data-driven go-to-market decisions and optimize channel mix for sustainable growth.
 
-This is not a channel strategy framework—it's a financial lens for channel evaluation that helps you avoid scaling unprofitable channels or killing channels with fixable problems. Use when deciding how to allocate marketing budget across channels.
-
 ## Key Concepts
 
 ### The Channel Evaluation Framework
@@ -57,30 +55,6 @@ A systematic approach to evaluate acquisition channels:
 | >3:1 | <12mo | Good retention | High volume | **Scale aggressively** |
 | 2-3:1 | 12-18mo | Average retention | Medium volume | **Test & optimize** |
 | <2:1 | >18mo | Poor retention | Low volume | **Kill or fix** |
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not vanity metrics:** "We got 10,000 signups!" means nothing if they churn in 30 days
-- **Not CAC-only thinking:** Low CAC with terrible retention is worse than high CAC with great retention
-- **Not ignoring payback:** 5:1 LTV:CAC with 36-month payback is a cash trap
-- **Not scaling broken channels:** Pouring money into inefficient channels accelerates failure
-
-### When to Use This Framework
-
-**Use this when:**
-- Evaluating whether to scale a new channel (content, paid, events, etc.)
-- Deciding how to allocate marketing budget across channels
-- Assessing whether to kill an underperforming channel
-- Comparing channels to optimize ROI
-- Planning annual marketing budget allocation
-
-**Don't use this when:**
-- Channel is brand-new (<3 months, <100 customers) — not enough data
-- You're testing channel fit (this is for evaluation, not experimentation)
-- Strategic channels (e.g., enterprises require field sales regardless of CAC)
-- You don't have channel-level data (need to track CAC, retention by source)
-
----
 
 ### Facilitation Source of Truth
 
@@ -533,93 +507,18 @@ See `examples/` folder for sample conversation flows. Mini examples below:
 
 ## Common Pitfalls
 
-### Pitfall 1: Scaling Broken Channels
-**Symptom:** "Let's 10x our Google Ads spend!" (LTV:CAC is 1.5:1)
-
-**Consequence:** You accelerate cash burn without improving unit economics. Lose money faster.
-
-**Fix:** Only scale channels with LTV:CAC >3:1 and payback <12 months. Fix broken channels before scaling.
-
----
-
-### Pitfall 2: Ignoring Customer Quality
-**Symptom:** "CAC is only $100!" (but customers churn in 30 days)
-
-**Consequence:** Low CAC means nothing if LTV is also low. You're acquiring churners, not customers.
-
-**Fix:** Track cohort retention and NRR by channel. Low CAC + high churn = bad channel.
-
----
-
-### Pitfall 3: Celebrating Vanity Metrics
-**Symptom:** "We got 10,000 signups from this campaign!" (5% convert to paid)
-
-**Consequence:** Signups don't pay bills. CAC is calculated on paid customers, not signups.
-
-**Fix:** Track CAC on paid customers only. Ignore vanity metrics like signups, impressions, clicks.
-
----
-
-### Pitfall 4: Averaging Across Channels
-**Symptom:** "Blended CAC is $500" (but hiding that one channel is $10K CAC)
-
-**Consequence:** Bad channels hide in blended metrics. You don't know which channels to kill.
-
-**Fix:** Track CAC, LTV, payback by channel. Compare channels individually.
-
----
-
-### Pitfall 5: Short-Term CAC Optimization
-**Symptom:** "We reduced CAC 50%!" (by targeting low-intent, low-LTV customers)
-
-**Consequence:** CAC dropped but so did LTV. Unit economics got worse, not better.
-
-**Fix:** Optimize for LTV:CAC ratio, not CAC alone. Higher CAC with higher LTV is better.
-
----
-
-### Pitfall 6: Ignoring Payback Period
-**Symptom:** "LTV:CAC is 6:1, this channel is amazing!" (payback is 48 months)
-
-**Consequence:** You run out of cash before recovering CAC. Great ratio, terrible cash flow.
-
-**Fix:** Pair LTV:CAC with payback period. 3:1 with 8-month payback beats 6:1 with 36-month payback.
-
----
-
-### Pitfall 7: Killing Channels Too Early
-**Symptom:** "This channel didn't work after 2 weeks"
-
-**Consequence:** Channels need time to optimize. Killing too early wastes learning.
-
-**Fix:** Give channels 3-6 months and 100+ customers before evaluating. Track trends, not snapshots.
-
----
-
-### Pitfall 8: Over-Relying on One Channel
-**Symptom:** "90% of our customers come from Google Ads"
-
-**Consequence:** Algorithm change, competitor outbids you, channel saturates = business grinds to halt.
-
-**Fix:** Diversify channels. No single channel should be >50% of new customer acquisition.
-
----
-
-### Pitfall 9: Forgetting Incrementality
-**Symptom:** "This retargeting campaign has great ROI!" (but customers would've converted anyway)
-
-**Consequence:** You're paying for conversions that would happen organically. Inflated ROI.
-
-**Fix:** Test incrementality with holdout groups. Only count truly incremental conversions.
-
----
-
-### Pitfall 10: Strategic Channels Without Limits
-**Symptom:** "Enterprise events are strategic, we can't stop!" (losing $500K/year)
-
-**Consequence:** "Strategic" becomes an excuse for burning cash indefinitely.
-
-**Fix:** Cap spend on strategic channels. Set timeline for improvement (6-12 months). If no progress, kill.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Scaling broken channels** | "10x Google Ads spend!" (LTV:CAC 1.5:1) | Only scale channels with LTV:CAC >3:1 and payback <12 months |
+| **Ignoring customer quality** | "CAC is only $100!" (customers churn in 30 days) | Track cohort retention and NRR by channel |
+| **Celebrating vanity metrics** | "10,000 signups!" (5% convert to paid) | Track CAC on paid customers only |
+| **Averaging across channels** | "Blended CAC is $500" (hiding $10K channel) | Track CAC, LTV, payback per channel individually |
+| **Short-term CAC optimization** | "Reduced CAC 50%!" (targeting low-LTV customers) | Optimize for LTV:CAC ratio, not CAC alone |
+| **Ignoring payback period** | "LTV:CAC is 6:1!" (payback is 48 months) | Pair LTV:CAC with payback; 3:1 at 8-month beats 6:1 at 36-month |
+| **Killing channels too early** | "Didn't work after 2 weeks" | Give 3-6 months and 100+ customers before evaluating |
+| **Over-relying on one channel** | "90% of customers from Google Ads" | Diversify; no single channel >50% of acquisition |
+| **Forgetting incrementality** | "Retargeting has great ROI!" (organic converts) | Test incrementality with holdout groups |
+| **Strategic channels without limits** | "Events are strategic, can't stop!" (losing $500K/yr) | Cap spend; set 6-12 month improvement timeline |
 
 ---
 

--- a/skills/ai-shaped-readiness-advisor/SKILL.md
+++ b/skills/ai-shaped-readiness-advisor/SKILL.md
@@ -21,8 +21,6 @@ Assess whether your product work is **"AI-first"** (using AI to automate existin
 
 **Key Distinction:** AI-first is cute (using Copilot to write PRDs faster). AI-shaped is survival (building a durable "reality layer" that both humans and AI trust, orchestrating AI workflows, compressing learning cycles).
 
-This is not about AI tools—it's about **organizational redesign around AI as co-intelligence**. The interactive skill guides you through a maturity assessment, then recommends your next move.
-
 ## Key Concepts
 
 ### AI-First vs. AI-Shaped
@@ -134,31 +132,6 @@ Moving beyond efficiency to create **defensible competitive advantages**.
 
 **AI-first version:** "We use AI to write better docs"
 **AI-shaped version:** "We validate product hypotheses in 2 days vs. industry standard 3 weeks—ship 6x more validated features per quarter"
-
----
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not about AI tools:** Using Claude vs. ChatGPT doesn't matter. Redesigning workflows matters.
-- **Not about speed:** Writing PRDs 2x faster isn't strategic if PRDs weren't the bottleneck.
-- **Not about automation:** Automating bad processes just scales the bad.
-- **Not about replacing humans:** AI-shaped orgs augment judgment, not eliminate it.
-
----
-
-### When to Use This Skill
-
-✅ **Use this when:**
-- You're using AI tools but not seeing strategic advantage
-- You suspect you're "AI-first" (efficiency) but want to be "AI-shaped" (transformation)
-- You need to prioritize which AI capability to build next
-- Leadership asks "How are we using AI?" and you're not sure how to answer strategically
-- You want to assess team readiness for AI-powered product work
-
-❌ **Don't use this when:**
-- You haven't started using AI at all (start with basic tools first)
-- You're looking for tool recommendations (this is about organizational design, not tooling)
-- You need tactical "how to write a prompt" guidance (use skills for that)
 
 ---
 
@@ -858,48 +831,13 @@ Would you like me to create a progress tracker for your AI-shaped transformation
 
 ## Common Pitfalls
 
-### 1. **Mistaking Efficiency for Differentiation**
-**Failure Mode:** "We use AI to write PRDs 2x faster—we're AI-shaped!"
-
-**Consequence:** Competitors copy within 3 months; no lasting advantage.
-
-**Fix:** Ask: "If a competitor threw 2x more people at this, could they match us?" If yes, it's efficiency (table stakes), not differentiation.
-
----
-
-### 2. **Skipping Context Design**
-**Failure Mode:** Building Agent Orchestration workflows without durable context.
-
-**Consequence:** AI workflows are fragile (context changes break everything).
-
-**Fix:** Context Design is foundational. Don't skip it. Build constraints registry, glossary, evidence standards first.
-
----
-
-### 3. **Individual Usage, Not Team Transformation**
-**Failure Mode:** "I'm AI-shaped, but my team isn't."
-
-**Consequence:** Can't scale; workflows die when you're on vacation.
-
-**Fix:** Prioritize Team-AI Facilitation. Shared norms > individual productivity.
-
----
-
-### 4. **Focusing on Tools, Not Workflows**
-**Failure Mode:** "Should we use Claude or ChatGPT?"
-
-**Consequence:** Tool debates distract from organizational redesign.
-
-**Fix:** Tools don't matter. Workflows matter. Focus on redesigning how work gets done, not which AI you use.
-
----
-
-### 5. **Speed Over Learning**
-**Failure Mode:** "AI helps us ship faster!"
-
-**Consequence:** Ship the wrong thing faster (if you're not compressing learning cycles).
-
-**Fix:** Outcome Acceleration is about learning faster, not building faster. Validate hypotheses in days, not weeks.
+| Pitfall | Failure Mode | Fix |
+|---------|-------------|-----|
+| **Mistaking efficiency for differentiation** | "We write PRDs 2x faster — we're AI-shaped!" | Ask: "Could a competitor match this by throwing more people at it?" If yes, it's table stakes |
+| **Skipping Context Design** | Building orchestration workflows without durable context | Context Design is foundational; build constraints registry, glossary, evidence standards first |
+| **Individual usage, not team transformation** | "I'm AI-shaped, but my team isn't" | Prioritize Team-AI Facilitation; shared norms > individual productivity |
+| **Focusing on tools, not workflows** | "Should we use Claude or ChatGPT?" | Tools don't matter. Focus on redesigning how work gets done |
+| **Speed over learning** | "AI helps us ship faster!" | Outcome Acceleration is about learning faster, not building faster |
 
 ---
 

--- a/skills/altitude-horizon-framework/SKILL.md
+++ b/skills/altitude-horizon-framework/SKILL.md
@@ -16,12 +16,6 @@ scenarios:
 estimated_time: "10-15 min"
 ---
 
-## Purpose
-
-Defines the two-axis mental model that distinguishes Director-level thinking from PM thinking: **Altitude** (how wide you zoom out) and **Horizon** (how far ahead you look). Use this to understand what actually changes in the transition, diagnose which transition zone is creating friction, and apply the Cascading Context Map when organizational direction is vague or absent.
-
-This is not a seniority hierarchy. A PM operating at the right altitude for their role is doing excellent work. A Director operating at PM altitude is leaving their actual job undone.
-
 ## Key Concepts
 
 ### The Two Axes
@@ -200,39 +194,12 @@ See `examples/sample.md` for a full worked scenario with a completed Cascading C
 
 ## Common Pitfalls
 
-### Pitfall 1: Altitude Theater
-**Symptom:** Using strategy language ("portfolio," "ecosystem," "long-term vision") while still making sprint-level decisions
-
-**Consequence:** You sound like a Director but function like a PM. Your team is confused about who's actually deciding and at what level.
-
-**Fix:** If you're in the details, own it. If you're not, delegate it fully. Mixing altitude levels without signaling creates ambiguity that erodes team trust.
-
----
-
-### Pitfall 2: One-and-Done Context Cascade
-**Symptom:** Running the Cascading Context Map once at annual planning, then never revisiting it
-
-**Consequence:** Team aligns in Q1 and drifts as strategy evolves. By Q3, team work is decoupled from current priorities.
-
-**Fix:** Revisit the cascade at major inflection points — quarterly planning, significant exec changes, pivots, or org restructuring.
-
----
-
-### Pitfall 3: Confusing Kindness with Leadership
-**Symptom:** Shielding the team from hard decisions, over-explaining constraints you're holding, softening feedback into meaninglessness
-
-**Consequence:** Team operates without accurate context; trust erodes when reality eventually lands without warning.
-
-**Fix:** Be transparent about the "why" behind hard decisions. You don't need to share everything — but what you share should be honest and actionable.
-
----
-
-### Pitfall 4: Premature Director Thinking as a PM
-**Symptom:** Spending PM years worried about portfolio strategy, organizational dynamics, and "thinking above your pay grade"
-
-**Consequence:** You under-serve your current role. PMs who think like Directors often miss the customer-level signal their actual role requires.
-
-**Fix:** Play your current role with full commitment. The transition will demand Director thinking soon enough — you'll be ready because you did your PM work well, not because you rehearsed the Director role prematurely.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Altitude theater | Using strategy language while still making sprint-level decisions | If you're in the details, own it. If you're not, delegate fully. Mixing altitude levels creates ambiguity |
+| One-and-done context cascade | Running the Cascading Context Map once, never revisiting | Revisit at major inflection points — quarterly planning, exec changes, pivots, or restructuring |
+| Confusing kindness with leadership | Shielding team from hard decisions, softening feedback into meaninglessness | Be transparent about the "why" behind hard decisions; what you share should be honest and actionable |
+| Premature Director thinking as a PM | Spending PM years worried about portfolio strategy and org dynamics | Play your current role with full commitment; Director readiness shows in PM work quality, not rehearsal |
 
 ---
 

--- a/skills/business-health-diagnostic/SKILL.md
+++ b/skills/business-health-diagnostic/SKILL.md
@@ -20,8 +20,6 @@ estimated_time: "20-30 min"
 
 Diagnose overall SaaS business health by analyzing growth, retention, unit economics, and capital efficiency metrics together. Use this to identify problems early, prioritize actions by urgency, and deliver a comprehensive health scorecard for board meetings, quarterly reviews, or fundraising preparation.
 
-This is not a single-metric check—it's a holistic diagnostic that connects revenue, retention, economics, and efficiency to reveal systemic issues and opportunities.
-
 ## Key Concepts
 
 ### The Business Health Framework
@@ -100,30 +98,6 @@ A SaaS business is healthy when four dimensions work together:
 - Magic Number 0.3-0.5
 - Operating leverage negative
 - Churn rate stable but high (>5% monthly)
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not a single metric:** "Revenue is growing 50%, we're great!" (ignoring burn, churn, unit economics)
-- **Not stage-agnostic:** Early-stage burn is acceptable; scale-stage burn is a problem
-- **Not static:** Health is directional—are metrics improving or degrading?
-- **Not just numbers:** Context matters (competitive pressure, market changes, team capacity)
-
-### When to Use This Framework
-
-**Use this when:**
-- Preparing for board meetings or investor updates
-- Quarterly business reviews (QBR)
-- Fundraising preparation (know your numbers)
-- Annual planning (identify improvement areas)
-- You suspect problems but can't pinpoint them
-- New PM/exec joining and needs health assessment
-
-**Don't use this when:**
-- You're pre-revenue (focus on product-market fit first)
-- You're in pure research mode (not enough data)
-- You need tactical guidance (use specific skills: feature, channel, pricing)
-
----
 
 ### Facilitation Source of Truth
 
@@ -716,48 +690,13 @@ See `examples/` folder. Mini examples below:
 
 ## Common Pitfalls
 
-### Pitfall 1: Celebrating Single Metrics
-**Symptom:** "Revenue growing 50%!" (ignoring burn, churn, unit economics)
-
-**Consequence:** Unsustainable growth. Scaling broken model.
-
-**Fix:** Look at all four dimensions together.
-
----
-
-### Pitfall 2: Ignoring Stage-Specific Benchmarks
-**Symptom:** "We're not profitable yet, is that bad?" (early-stage company)
-
-**Consequence:** Misplaced worry. Early-stage should optimize for growth and unit economics, not profitability.
-
-**Fix:** Use stage-appropriate benchmarks.
-
----
-
-### Pitfall 3: Focusing on Lagging Indicators Only
-**Symptom:** "Churn is 5%, let's watch it"
-
-**Consequence:** By the time lagging indicators (churn, NRR) show problems, it's late.
-
-**Fix:** Track leading indicators (usage, engagement, onboarding completion).
-
----
-
-### Pitfall 4: Not Acting on Red Flags
-**Symptom:** "NRR <100% for 3 quarters, but we'll fix it eventually"
-
-**Consequence:** Problems compound. Becomes crisis.
-
-**Fix:** Set clear timelines. If metric doesn't improve in X time, escalate.
-
----
-
-### Pitfall 5: Trying to Fix Everything at Once
-**Symptom:** "Let's improve growth, retention, CAC, and efficiency simultaneously"
-
-**Consequence:** Resources spread thin. Nothing improves.
-
-**Fix:** Prioritize top 1-3 issues. Fix sequentially.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Celebrating single metrics** | "Revenue growing 50%!" (ignoring burn, churn) | Look at all four dimensions together |
+| **Ignoring stage-specific benchmarks** | "We're not profitable yet, is that bad?" (early-stage) | Use stage-appropriate benchmarks |
+| **Focusing on lagging indicators only** | "Churn is 5%, let's watch it" | Track leading indicators (usage, engagement, onboarding) |
+| **Not acting on red flags** | "NRR <100% for 3 quarters, we'll fix it eventually" | Set clear timelines; escalate if no improvement |
+| **Trying to fix everything at once** | Improving growth, retention, CAC, and efficiency simultaneously | Prioritize top 1-3 issues; fix sequentially |
 
 ---
 

--- a/skills/company-research/SKILL.md
+++ b/skills/company-research/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Create a comprehensive company profile that extracts executive insights, product strategy, transformation initiatives, and organizational dynamics from publicly available sources. Use this to understand competitive landscape, evaluate partnership opportunities, benchmark best practices, prepare for interviews, or inform market entry decisions by understanding how successful companies think about product management and strategy.
 
-This is not surface-level research—it's strategic intelligence gathering focused on product management perspectives and executive vision.
-
 ## Key Concepts
 
 ### The Executive Insights Framework
@@ -25,31 +23,6 @@ This framework synthesizes company intelligence across multiple dimensions:
 5. **Organizational Impact:** How PM influences strategy, cross-functional collaboration
 6. **Future Roadmap:** Upcoming initiatives and anticipated challenges
 7. **Product-Led Growth (PLG):** PLG strategies, data-driven decisions
-
-### Why This Works
-- **Executive perspective:** Captures leadership thinking, not just marketing copy
-- **Product-centric:** Focuses on PM-relevant insights (strategy, process, culture)
-- **Multi-source:** Synthesizes interviews, earnings calls, blog posts, case studies
-- **Strategic intelligence:** Informs competitive positioning, partnership evaluation, or interview prep
-
-### Anti-Patterns (What This Is NOT)
-- **Not financial analysis:** Focus is product strategy, not valuation or stock performance
-- **Not SWOT analysis:** This documents their perspective, not strengths/weaknesses assessment
-- **Not surface scraping:** Go deeper than "About Us" pages—find executive interviews, product blogs, earnings transcripts
-
-### When to Use This
-- Competitive analysis (understanding how competitors approach PM)
-- Partnership evaluation (assessing cultural fit and strategic direction)
-- Interview preparation (understanding company culture, product philosophy)
-- Benchmarking best practices (learning from successful companies)
-- Market entry decisions (understanding how incumbents operate)
-
-### When NOT to Use This
-- For internal analysis (this is external research)
-- When primary sources are unavailable (executives haven't spoken publicly)
-- As a substitute for customer research (this is company perspective, not customer perspective)
-
----
 
 ## Application
 
@@ -315,48 +288,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Surface-Level Research
-**Symptom:** "Stripe is a payments company. They process payments."
-
-**Consequence:** No strategic insights.
-
-**Fix:** Go deeper—find executive interviews, engineering blogs, product philosophy posts.
-
----
-
-### Pitfall 2: No Source Citations
-**Symptom:** "The CEO said the company is focused on innovation"
-
-**Consequence:** Unverifiable, low credibility.
-
-**Fix:** Always cite source and date: "The CEO said X (Source: Lenny's Podcast, Episode 185, Sept 2023)."
-
----
-
-### Pitfall 3: Mixing Opinion with Facts
-**Symptom:** "Stripe's product strategy is great because they focus on developers"
-
-**Consequence:** Analysis, not research.
-
-**Fix:** Document *what* they do, not whether it's "good." Save analysis for "Key Takeaways."
-
----
-
-### Pitfall 4: Outdated Information
-**Symptom:** Using 5-year-old quotes or strategies
-
-**Consequence:** Irrelevant insights (company strategies evolve).
-
-**Fix:** Prioritize sources from the last 12-24 months.
-
----
-
-### Pitfall 5: Ignoring Negative Signals
-**Symptom:** Only documenting successes, ignoring challenges or failures
-
-**Consequence:** Incomplete picture.
-
-**Fix:** Include "Anticipated Market Challenges" and competitive threats.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Surface-level research** | "Stripe is a payments company. They process payments." | Find executive interviews, engineering blogs, product philosophy posts |
+| **No source citations** | "The CEO said the company is focused on innovation" | Always cite source and date (e.g., "Lenny's Podcast, Ep 185, Sept 2023") |
+| **Mixing opinion with facts** | "Stripe's product strategy is great because..." | Document *what* they do, not whether it's "good"; save analysis for Key Takeaways |
+| **Outdated information** | Using 5-year-old quotes or strategies | Prioritize sources from the last 12-24 months |
+| **Ignoring negative signals** | Only documenting successes | Include anticipated challenges and competitive threats |
 
 ---
 
@@ -377,9 +315,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/company-profile-executive-insights-research.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `company-research.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/positioning-statement/SKILL.md`, `skills/pestel-analysis/SKILL.md`

--- a/skills/context-engineering-advisor/SKILL.md
+++ b/skills/context-engineering-advisor/SKILL.md
@@ -21,8 +21,6 @@ Guide product managers through diagnosing whether they're doing **context stuffi
 
 **Key Distinction:** Context stuffing assumes volume = quality ("paste the entire PRD"). Context engineering treats AI attention as a scarce resource and allocates it deliberately.
 
-This is not about prompt writing—it's about **designing the information architecture** that grounds AI in reality without overwhelming it with noise.
-
 ## Key Concepts
 
 ### The Paradigm Shift: Parametric → Contextual Intelligence
@@ -134,31 +132,6 @@ Ask these to identify context stuffing:
 4. **Implement:** Fresh session using **only** the high-density plan as context
 
 **Why This Works:** Context rot is eliminated; agent starts clean with compressed, high-signal context.
-
----
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not about choosing AI tools** — Claude vs. ChatGPT doesn't matter; architecture matters
-- **Not about writing better prompts** — This is systems design, not copywriting
-- **Not about adding more tokens** — "Infinite context" narratives are marketing, not engineering reality
-- **Not about replacing human judgment** — Context engineering amplifies judgment, doesn't eliminate it
-
----
-
-### When to Use This Skill
-
-✅ **Use this when:**
-- You're pasting entire PRDs/codebases into AI and getting vague responses
-- AI outputs are inconsistent ("works sometimes, not others")
-- You're burning tokens without seeing accuracy improvements
-- You suspect you're "context stuffing" but don't know how to fix it
-- You need to design context architecture for an AI product feature
-
-❌ **Don't use this when:**
-- You're just getting started with AI (start with basic prompts first)
-- You're looking for tool recommendations (this is about architecture, not tooling)
-- Your AI usage is working well (if it ain't broke, don't fix it)
 
 ---
 
@@ -696,48 +669,13 @@ Would you like me to:
 
 ## Common Pitfalls
 
-### 1. **"Infinite Context" Marketing vs. Engineering Reality**
-**Failure Mode:** Believing "1 million token context windows" means you should use all of them.
-
-**Consequence:** Reasoning Noise degrades performance; accuracy drops below 20% past ~32k tokens.
-
-**Fix:** Context windows are not free. Treat tokens as scarce; optimize for density, not volume.
-
----
-
-### 2. **Retrying Instead of Restructuring**
-**Failure Mode:** "It works if I run it 3 times" → normalizing retries instead of fixing structure.
-
-**Consequence:** Wastes time and money; masks deeper context rot issues.
-
-**Fix:** If retries are common, your context structure is broken. Apply Q5 (fix structure, don't add volume).
-
----
-
-### 3. **No Context Boundary Owner**
-**Failure Mode:** Ad-hoc, implicit context decisions → unbounded growth.
-
-**Consequence:** Six months later, every query stuffs 100k tokens per interaction.
-
-**Fix:** Assign explicit ownership; create Context Manifest; schedule quarterly audits.
-
----
-
-### 4. **Mixing Always-Needed with Episodic**
-**Failure Mode:** Persisting historical data that should be retrieved on-demand.
-
-**Consequence:** Context window crowded with irrelevant information; attention diluted.
-
-**Fix:** Apply Q2 test: persist only what's needed in 80%+ of interactions; retrieve the rest.
-
----
-
-### 5. **Skipping the Reset Phase**
-**Failure Mode:** Never clearing context window during Research→Plan→Implement cycle.
-
-**Consequence:** Context rot accumulates; goal drift; dead ends poison implementation.
-
-**Fix:** Mandatory Reset phase after Plan; start implementation with only high-density plan as context.
+| Pitfall | Failure Mode | Fix |
+|---------|-------------|-----|
+| **"Infinite Context" thinking** | Believing large context windows mean you should fill them | Treat tokens as scarce; accuracy drops below 20% past ~32k tokens |
+| **Retrying instead of restructuring** | "It works if I run it 3 times" normalizes bad structure | If retries are common, fix context structure (Q5) |
+| **No context boundary owner** | Ad-hoc decisions → unbounded growth to 100k+ tokens | Assign ownership; create Context Manifest; quarterly audits |
+| **Mixing always-needed with episodic** | Persisting historical data that should be retrieved on-demand | Persist only what's needed in 80%+ of interactions (Q2 test) |
+| **Skipping the Reset phase** | Never clearing context during Research→Plan→Implement | Mandatory Reset after Plan; implement with only high-density plan |
 
 ---
 

--- a/skills/customer-journey-map/SKILL.md
+++ b/skills/customer-journey-map/SKILL.md
@@ -19,8 +19,6 @@ estimated_time: "20-30 min"
 ## Purpose
 Create a comprehensive customer journey map that visualizes how customers interact with your brand across all stages—from awareness to loyalty—documenting their actions, touchpoints, emotions, KPIs, business goals, and teams involved at each stage. Use this to identify pain points, align cross-functional teams, and systematically improve the customer experience to achieve business objectives.
 
-This is not a user flow diagram—it's a strategic artifact that combines customer empathy with business metrics to drive actionable improvements.
-
 ## Key Concepts
 
 ### The Customer Journey Mapping Framework
@@ -40,30 +38,6 @@ Adapted from NNGroup's framework and Carnegie Mellon's PM curriculum, a customer
 - **KPIs:** Metrics to measure success
 - **Business Goals:** What you're trying to achieve
 - **Teams Involved:** Who owns this stage
-
-### Why This Works
-- **Empathy-driven:** Centers on customer emotions, not just actions
-- **Cross-functional alignment:** Shows which teams affect which stages
-- **Metric-focused:** Ties customer experience to measurable outcomes
-- **Gap identification:** Makes pain points and opportunities visible
-- **Actionable:** Clear KPIs and goals enable prioritization
-
-### Anti-Patterns (What This Is NOT)
-- **Not a user story map:** Journey maps are broader (all touchpoints, not just product use)
-- **Not a service blueprint:** Less detailed on internal processes, more focused on customer experience
-- **Not static:** Journey maps evolve as customer behavior changes
-
-### When to Use This
-- Understanding customer experience across all touchpoints (not just product)
-- Aligning cross-functional teams (marketing, sales, product, support)
-- Identifying pain points and prioritizing improvements
-- Onboarding new team members to customer perspective
-- Auditing the end-to-end customer experience
-
-### When NOT to Use This
-- For deep product-specific workflows (use story mapping instead)
-- Before defining personas (need to know who you're mapping)
-- As a one-time exercise (journey maps require ongoing updates)
 
 ---
 
@@ -274,48 +248,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Generic Emotions
-**Symptom:** "Customer feels happy" or "Customer is satisfied"
-
-**Consequence:** No insight into *why* they feel that way or what to improve.
-
-**Fix:** Be specific: "Relieved that setup took 30 minutes, not 3 hours as feared."
-
----
-
-### Pitfall 2: Missing Touchpoints
-**Symptom:** Only documenting digital touchpoints (website, app)
-
-**Consequence:** Miss offline interactions (conferences, word-of-mouth, support calls).
-
-**Fix:** Include all touchpoints: physical, digital, human, and automated.
-
----
-
-### Pitfall 3: Internal Perspective
-**Symptom:** Mapping what *you* want customers to do, not what they *actually* do
-
-**Consequence:** Journey map reflects wishful thinking, not reality.
-
-**Fix:** Validate with customer research, analytics, and support tickets.
-
----
-
-### Pitfall 4: No KPIs or Goals
-**Symptom:** Journey map has actions and emotions but no metrics or business objectives
-
-**Consequence:** No way to measure success or prioritize improvements.
-
-**Fix:** Add KPIs and business goals for each stage. Make them measurable.
-
----
-
-### Pitfall 5: One-and-Done Exercise
-**Symptom:** Journey map created once, never updated
-
-**Consequence:** Map becomes outdated as customer behavior evolves.
-
-**Fix:** Review quarterly. Update based on new data, product changes, or market shifts.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Generic Emotions | "Customer feels happy" — no insight into why | Be specific: "Relieved that setup took 30 minutes, not 3 hours as feared" |
+| Missing Touchpoints | Only documenting digital touchpoints | Include all touchpoints: physical, digital, human, and automated |
+| Internal Perspective | Mapping what you *want* customers to do, not what they actually do | Validate with customer research, analytics, and support tickets |
+| No KPIs or Goals | Actions and emotions but no metrics or business objectives | Add KPIs and business goals for each stage; make them measurable |
+| One-and-Done Exercise | Journey map created once, never updated | Review quarterly; update based on new data, product changes, or market shifts |
 
 ---
 
@@ -338,9 +277,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/customer-journey-mapping-prompt-template.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `customer-journey-map.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/proto-persona/SKILL.md`, `skills/jobs-to-be-done/SKILL.md`, `skills/problem-statement/SKILL.md`

--- a/skills/customer-journey-mapping-workshop/SKILL.md
+++ b/skills/customer-journey-mapping-workshop/SKILL.md
@@ -18,13 +18,7 @@ scenarios:
 ## Purpose
 Guide product managers through creating a customer journey map by asking adaptive questions about the actor (persona), scenario/goal, journey phases, actions/emotions, and opportunities for improvement. Use this to visualize the end-to-end customer experience, identify pain points, and create a shared mental model across teams—avoiding surface-level feature lists and ensuring discovery work focuses on real customer problems, not assumed solutions.
 
-This is not a feature roadmap—it's a discovery and alignment tool that uncovers where the experience breaks down and where improvements will have the greatest impact.
-
 ## Key Concepts
-
-### What is a Customer Journey Map?
-
-A journey map (NNGroup) visualizes "the process that a person goes through in order to accomplish a goal." It compiles user actions into a timeline, enriched with thoughts and emotions to create a narrative, then condenses and polishes into a visual artifact.
 
 ### Five Key Components (NNGroup Framework)
 
@@ -48,28 +42,6 @@ Emotions: 😊😐😞    Emotions:        Emotions:       Emotions:       Emoti
    ↓                  ↓                ↓               ↓               ↓
 Opportunities:     Opportunities:   Opportunities:  Opportunities:  Opportunities:
 ```
-
-### Why This Works
-- **Forces conversation:** Teams align on shared understanding of customer experience
-- **Reveals pain points:** Emotions + actions highlight where experience breaks down
-- **Prioritizes improvements:** Opportunities ranked by impact guide roadmap decisions
-- **Human-centered:** Focuses on customer perspective, not internal processes
-
-### Anti-Patterns (What This Is NOT)
-- **Not a service blueprint:** Journey maps focus on customer perspective; service blueprints map internal operations
-- **Not a user story map:** Journey maps support discovery; user story maps facilitate implementation planning
-- **Not an experience map:** Journey maps target specific users and products; experience maps explore broader human behaviors
-
-### When to Use This
-- Starting customer discovery (understanding current experience)
-- Identifying pain points for retention/engagement initiatives
-- Aligning cross-functional teams on customer perspective
-- Prioritizing which problems to solve first
-
-### When NOT to Use This
-- When you already understand the customer journey deeply
-- For technical refactoring (no customer-facing journey)
-- As a substitute for user research (maps require research input)
 
 ---
 
@@ -419,11 +391,6 @@ Pain Points:
 2. Simplify terminology (MEDIUM — affects understanding)
 3. Reduce required form fields (MEDIUM — affects completion rate)
 
-**Why this works:**
-- Emotions + actions reveal pain points clearly
-- Opportunities tied to specific phases
-- Evidence from research (drop-off data, support tickets)
-
 ---
 
 ### Example 2: Bad Journey Map (Too Generic)
@@ -440,62 +407,19 @@ Pain Points:
 **Emotions:**
 - Happy 😊
 
-**Why this fails:**
-- No specificity (what tasks? which features?)
-- No pain points identified (everything is "good")
-- Can't extract actionable opportunities
-
-**Fix:**
-- Get specific: "User creates invoice → sends to client → tracks payment status"
-- Include real customer quotes: "I wish I could bulk-send invoices"
-- Show emotional highs AND lows (not just happy)
+**Fix:** Get specific ("User creates invoice → sends to client → tracks payment status"), include real customer quotes, and show emotional highs AND lows.
 
 ---
 
 ## Common Pitfalls
 
-### Pitfall 1: Mapping Internal Process, Not Customer Experience
-**Symptom:** Journey phases = "Lead generated → Qualified → Demo scheduled → Deal closed"
-
-**Consequence:** Focuses on sales process, not customer perspective
-
-**Fix:** Map from customer POV: "Discovers problem → Researches solutions → Tries product → Adopts"
-
----
-
-### Pitfall 2: No Emotions or Pain Points
-**Symptom:** Journey map lists actions only, no thoughts/emotions
-
-**Consequence:** Misses the point—can't identify where experience breaks down
-
-**Fix:** Add customer quotes, emotional states (frustrated, delighted, confused)
-
----
-
-### Pitfall 3: Too Many Personas in One Map
-**Symptom:** Trying to map "all users" in a single journey
-
-**Consequence:** Loses focus, becomes generic
-
-**Fix:** One map per persona. If multiple personas, create separate maps.
-
----
-
-### Pitfall 4: Opportunities Aren't Prioritized
-**Symptom:** List 20 opportunities with no ranking
-
-**Consequence:** Team paralyzed, doesn't know where to start
-
-**Fix:** Rank by impact (HIGH/MEDIUM/LOW) based on evidence and emotional intensity
-
----
-
-### Pitfall 5: Map Created in Isolation
-**Symptom:** PM creates journey map alone, doesn't involve team
-
-**Consequence:** No shared mental model, map doesn't drive decisions
-
-**Fix:** Facilitate workshop with cross-functional team (PM, design, engineering, support)
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Mapping Internal Process | Phases = "Lead generated → Qualified → Demo → Closed" | Map from customer POV: "Discovers → Researches → Tries → Adopts" |
+| No Emotions or Pain Points | Journey lists actions only | Add customer quotes, emotional states (frustrated, delighted, confused) |
+| Too Many Personas | Trying to map "all users" in one journey | One map per persona. Create separate maps for each |
+| Opportunities Not Prioritized | 20 opportunities with no ranking | Rank by impact (HIGH/MEDIUM/LOW) based on evidence and emotional intensity |
+| Map Created in Isolation | PM creates journey map alone | Facilitate workshop with cross-functional team |
 
 ---
 
@@ -515,9 +439,3 @@ Pain Points:
 ### Dean's Work
 - [If Dean has journey mapping resources, link here]
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `customer-journey-mapping-workshop.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** Uses `customer-journey-map.md`, `proto-persona.md`, `problem-statement.md`, `jobs-to-be-done.md`

--- a/skills/director-readiness-advisor/SKILL.md
+++ b/skills/director-readiness-advisor/SKILL.md
@@ -16,12 +16,6 @@ scenarios:
 estimated_time: "10-15 min"
 ---
 
-## Purpose
-
-Guide PMs and Directors through the specific challenges of the PM-to-Director transition using adaptive questions and targeted coaching. Diagnoses where you are in the journey and delivers practical, war-story-backed guidance calibrated to your situation — not generic leadership advice.
-
-This is not a readiness checklist. It's a coaching conversation that names what's actually hard, why it's hard, and what to do about it.
-
 ## Key Concepts
 
 ### The Four Transition Situations
@@ -306,30 +300,11 @@ See `examples/conversation-flow.md` for a full end-to-end interaction, including
 
 ## Common Pitfalls
 
-### Pitfall 1: Treating Preparation Like a Checklist
-**Symptom:** Asking "what do I need to do to get promoted?" and working through items like tasks
-
-**Consequence:** You optimize for appearances of readiness rather than building the actual muscles. Interviewers and managers can tell the difference.
-
-**Fix:** Use this advisor to identify the one or two specific behavior changes that matter most for your situation, not a comprehensive development program.
-
----
-
-### Pitfall 2: Misidentifying Your Situation
-**Symptom:** Selecting "preparing" when you're actually in an active interview process, or selecting "newly landed" when you've been in the role 18 months
-
-**Consequence:** You get coaching calibrated to the wrong situation.
-
-**Fix:** Be honest about where you actually are, not where you'd like to be.
-
----
-
-### Pitfall 3: Looking for Permission
-**Symptom:** Asking this advisor whether you're "ready" for the transition
-
-**Consequence:** There's no readiness test. The transition is a decision, not a graduation.
-
-**Fix:** Use this skill to identify what will be hardest for you specifically and how to address it — not to get a pass/fail verdict.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Treating preparation like a checklist | "What do I need to do to get promoted?" worked through like tasks | Identify the 1-2 specific behavior changes that matter most, not a comprehensive development program |
+| Misidentifying your situation | Selecting "preparing" when actually in active interviews | Be honest about where you actually are, not where you'd like to be |
+| Looking for permission | Asking whether you're "ready" for the transition | Use this skill to identify what will be hardest and how to address it — not for a pass/fail verdict |
 
 ---
 

--- a/skills/discovery-interview-prep/SKILL.md
+++ b/skills/discovery-interview-prep/SKILL.md
@@ -20,8 +20,6 @@ estimated_time: "15-20 min"
 ## Purpose
 Guide product managers through preparing for customer discovery interviews by asking adaptive questions about research goals, customer segments, constraints, and methodologies. Use this to design effective interview plans, craft targeted questions, avoid common biases, and maximize learning from limited customer access—ensuring discovery interviews yield actionable insights rather than confirmation bias or surface-level feedback.
 
-This is not a script generator—it's a strategic prep process that outputs a tailored interview plan with methodology, question framework, and success criteria.
-
 ## Key Concepts
 
 ### The Discovery Interview Prep Flow
@@ -31,29 +29,6 @@ An interactive process that:
 3. Identifies target customer segment and access constraints
 4. Recommends interview methodology (Jobs-to-be-Done, problem validation, switch interviews, etc.)
 5. Generates interview framework with questions, biases to avoid, and success metrics
-
-### Why This Works
-- **Goal-driven:** Aligns interview approach to what you need to learn
-- **Adaptive:** Adjusts methodology based on product stage (idea vs. existing product) and access constraints
-- **Bias-aware:** Highlights common pitfalls (leading questions, confirmation bias, solution-first thinking)
-- **Actionable:** Outputs interview guide ready to use
-
-### Anti-Patterns (What This Is NOT)
-- **Not a user testing script:** Discovery = learning problems; testing = validating solutions
-- **Not a sales demo:** Don't pitch—listen and learn
-- **Not surveys at scale:** Deep qualitative interviews (5-10 people), not broad surveys (100+ people)
-
-### When to Use This
-- Starting product discovery (validating problem space)
-- Repositioning an existing product (understanding new market)
-- Investigating churn or drop-off (retention interviews)
-- Evaluating feature ideas before building
-- Preparing for customer development sprints
-
-### When NOT to Use This
-- User testing a prototype (use usability testing frameworks instead)
-- Quantitative research at scale (use surveys, analytics)
-- When you already know the problem (move to solution validation)
 
 ---
 
@@ -342,48 +317,13 @@ You'll know these interviews are successful if:
 
 ## Common Pitfalls
 
-### Pitfall 1: Asking What Customers Want
-**Symptom:** "What features do you want us to build?"
-
-**Consequence:** You get feature requests, not problems. Customers don't know solutions.
-
-**Fix:** Ask about past behavior: "Tell me about the last time you struggled with X."
-
----
-
-### Pitfall 2: Pitching Instead of Listening
-**Symptom:** Spending 20 minutes explaining your product idea
-
-**Consequence:** Customer feels obligated to be nice. No honest feedback.
-
-**Fix:** Don't mention your solution until the last 5 minutes (if at all). Focus on their problems.
-
----
-
-### Pitfall 3: Interviewing the Wrong People
-**Symptom:** Interviewing friends, family, or people who don't experience the problem
-
-**Consequence:** Polite feedback, not real insights.
-
-**Fix:** Interview people who experience the problem regularly and recently.
-
----
-
-### Pitfall 4: Stopping at 1-2 Interviews
-**Symptom:** "We talked to 2 people, they liked it, let's build!"
-
-**Consequence:** Small sample = confirmation bias.
-
-**Fix:** Interview 5-10 people minimum. Look for patterns, not one-off feedback.
-
----
-
-### Pitfall 5: Not Recording Insights
-**Symptom:** Relying on memory after interviews
-
-**Consequence:** Lose details, misremember quotes, can't spot patterns.
-
-**Fix:** Record (with consent) or take detailed notes. Synthesize immediately after each interview.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Asking What Customers Want | "What features should we build?" | Ask about past behavior: "Tell me about the last time you struggled with X" |
+| Pitching Instead of Listening | 20 minutes explaining your product idea | Don't mention your solution until the last 5 minutes (if at all) |
+| Interviewing the Wrong People | Friends, family, or non-problem-havers | Interview people who experience the problem regularly and recently |
+| Stopping at 1-2 Interviews | "2 people liked it, let's build!" | Interview 5-10 minimum. Look for patterns, not one-off feedback |
+| Not Recording Insights | Relying on memory after interviews | Record (with consent) or take detailed notes. Synthesize immediately |
 
 ---
 
@@ -402,9 +342,3 @@ You'll know these interviews are successful if:
 ### Dean's Work
 - Problem Framing Canvas (synthesizes interview findings)
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `discovery-interview-prep.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** Uses `problem-statement.md`, `proto-persona.md`, `jobs-to-be-done.md`

--- a/skills/discovery-process/SKILL.md
+++ b/skills/discovery-process/SKILL.md
@@ -19,42 +19,7 @@ estimated_time: "30-60 min"
 ## Purpose
 Guide product managers through a complete discovery cycle—from initial problem hypothesis to validated solution—by orchestrating problem framing, customer interviews, synthesis, and experimentation skills into a structured process. Use this to systematically explore problem spaces, validate assumptions, and build confidence before committing to full development—avoiding "build it and they will come" syndrome and ensuring you're solving real customer problems.
 
-This is not a one-time research project—it's a continuous discovery practice that runs in parallel with delivery, typically 1-2 discovery cycles per quarter.
-
 ## Key Concepts
-
-### What is the Discovery Process?
-
-The discovery process (Teresa Torres, Marty Cagan) is a structured approach to exploring problem spaces and validating solutions before building. It consists of:
-
-1. **Frame the Problem** — Define what you're investigating and why
-2. **Conduct Research** — Gather qualitative and quantitative evidence
-3. **Synthesize Insights** — Identify patterns, pain points, and opportunities
-4. **Generate Solutions** — Explore multiple solution options
-5. **Validate Solutions** — Test assumptions through experiments
-6. **Decide & Document** — Commit to build, pivot, or kill
-
-### Why This Works
-- **De-risks product decisions:** Tests assumptions before expensive builds
-- **Customer-centric:** Grounds decisions in real customer problems, not internal opinions
-- **Iterative:** Builds confidence progressively through small experiments
-- **Fast learning:** Discovers "no-go" signals early, saves wasted effort
-
-### Anti-Patterns (What This Is NOT)
-- **Not waterfall research:** Discovery runs continuously, not once before dev
-- **Not user testing:** Discovery validates problems; testing validates solutions
-- **Not a substitute for shipping:** Discovery informs delivery, doesn't replace it
-
-### When to Use This
-- Exploring new product/feature areas
-- Investigating retention or churn problems
-- Validating strategic initiatives before roadmap commitment
-- Continuous discovery (weekly customer touchpoints)
-
-### When NOT to Use This
-- For well-understood problems (move to execution)
-- When stakeholders have already committed to a solution (address alignment first)
-- For tactical bug fixes or technical debt (no discovery needed)
 
 ---
 
@@ -418,48 +383,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Skipping Customer Interviews
-**Symptom:** Rely only on analytics and support tickets, no qualitative research
-
-**Consequence:** Miss "why" behind behavior, build wrong solutions
-
-**Fix:** Always interview 5-10 customers per discovery cycle (even if you have data)
-
----
-
-### Pitfall 2: Asking Leading Questions
-**Symptom:** "Would you use [feature X] if we built it?"
-
-**Consequence:** Confirmation bias, customers say "yes" to be polite
-
-**Fix:** Use Mom Test questions from `skills/discovery-interview-prep/SKILL.md` (focus on past behavior)
-
----
-
-### Pitfall 3: Not Reaching Saturation
-**Symptom:** Interview 2-3 customers, declare discovery complete
-
-**Consequence:** Small sample, not representative
-
-**Fix:** Continue interviews until same patterns emerge across 3+ customers (typically 5-7 interviews minimum)
-
----
-
-### Pitfall 4: Analysis Paralysis
-**Symptom:** Spend 6 weeks synthesizing insights, never move to solutions
-
-**Consequence:** No delivery, team loses momentum
-
-**Fix:** Time-box discovery to 3-4 weeks; after Phase 6, move to execution
-
----
-
-### Pitfall 5: Discovery as One-Time Activity
-**Symptom:** Run discovery once before building, then stop
-
-**Consequence:** Miss evolving customer needs, market changes
-
-**Fix:** Continuous discovery (Teresa Torres): 1 customer interview per week, ongoing
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Skipping Customer Interviews | Relying only on analytics and support tickets | Interview 5-10 customers per cycle, even if you have data |
+| Asking Leading Questions | "Would you use feature X?" | Use Mom Test questions from `skills/discovery-interview-prep/SKILL.md` |
+| Not Reaching Saturation | 2-3 interviews, declare done | Continue until patterns emerge across 3+ customers (5-7 minimum) |
+| Analysis Paralysis | 6 weeks synthesizing, no solutions | Time-box discovery to 3-4 weeks; move to execution after Phase 6 |
+| Discovery as One-Time Activity | Run once before building, then stop | Continuous discovery: 1 customer interview per week, ongoing |
 
 ---
 
@@ -496,9 +426,3 @@ Mini example excerpt:
 - Productside Blueprint — Strategic discovery process
 - [If Dean has discovery resources, link here]
 
----
-
-**Skill type:** Workflow
-**Suggested filename:** `discovery-process.md`
-**Suggested placement:** `/skills/workflows/`
-**Dependencies:** Orchestrates 10+ component and interactive skills across 6 phases

--- a/skills/eol-message/SKILL.md
+++ b/skills/eol-message/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Craft a clear, empathetic End-of-Life (EOL) message that communicates product or feature discontinuation, explains the rationale, addresses customer impact, provides transition support, and positions the replacement solution. Use this to maintain customer trust during difficult transitions and reduce churn by demonstrating care and offering a clear path forward.
 
-This is not a generic sunset announcement—it's a customer-centric communication that acknowledges loss while framing the change as progress.
-
 ## Key Concepts
 
 ### The EOL Messaging Framework
@@ -26,29 +24,6 @@ An effective EOL message balances honesty about the change with empathy for cust
 7. **Support measures:** How you'll help customers migrate
 8. **Timeline:** Key dates and milestones
 9. **Call to action:** Next steps and contact info
-
-### Why This Works
-- **Empathy-first:** Acknowledges customer disruption before justifying the decision
-- **Clarity:** No ambiguity about what's changing and when
-- **Support-focused:** Shows you're not abandoning customers mid-transition
-- **Future-oriented:** Frames change as progress, not loss
-
-### Anti-Patterns (What This Is NOT)
-- **Not a terse shutdown notice:** "We're discontinuing Product X. Goodbye."
-- **Not business-centric:** Don't lead with "This reduces our costs"
-- **Not vague:** "Soon" is not a timeline
-- **Not defensive:** Don't blame customers ("low usage forced us to shut down")
-
-### When to Use This
-- Discontinuing a product, feature, or service
-- Migrating customers from legacy to new platform
-- Sunsetting an acquisition target's product
-- Deprecating a technology stack or API
-
-### When NOT to Use This
-- For minor feature tweaks (don't over-communicate small changes)
-- Before you have a transition plan (communicate *after* you know how you'll support customers)
-- If you're secretly hoping customers won't notice (be transparent)
 
 ---
 
@@ -278,48 +253,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Business-Centric Rationale
-**Symptom:** "We're discontinuing Product X to reduce costs and consolidate our portfolio."
-
-**Consequence:** Customers feel like collateral damage in a business decision.
-
-**Fix:** Frame rationale around customer benefits: "We're consolidating to Product Y so we can invest 100% of resources in features you've requested."
-
----
-
-### Pitfall 2: Vague Timeline
-**Symptom:** "Product X will be discontinued soon."
-
-**Consequence:** Customers can't plan. Anxiety and churn increase.
-
-**Fix:** Provide specific dates: "March 1: Migration tool available. December 31: Full shutdown."
-
----
-
-### Pitfall 3: No Support Plan
-**Symptom:** "You'll need to migrate to Product Y. Good luck!"
-
-**Consequence:** Customers feel abandoned. High churn risk.
-
-**Fix:** Offer migration support: "1-on-1 assistance, auto-migration tool, 3-month discount, training resources."
-
----
-
-### Pitfall 4: Ignoring Customer Impact
-**Symptom:** Message jumps from announcement to "Here's the new product!"
-
-**Consequence:** Customers feel their concerns aren't acknowledged.
-
-**Fix:** Explicitly acknowledge impact: "We understand this requires time to migrate and learn new features."
-
----
-
-### Pitfall 5: Terse or Defensive Tone
-**Symptom:** "Due to low usage, we're shutting down Product X."
-
-**Consequence:** Sounds like you're blaming customers.
-
-**Fix:** Be empathetic and forward-looking: "We're consolidating to focus on the future of automation."
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Business-Centric Rationale | "Discontinuing to reduce costs" | Frame around customer benefits: "Investing 100% in features you requested" |
+| Vague Timeline | "Discontinued soon" | Specific dates: "March 1: Migration tool. December 31: Shutdown" |
+| No Support Plan | "Migrate to Product Y. Good luck!" | Offer migration support: 1-on-1 assistance, auto-migration, discounts |
+| Ignoring Customer Impact | Jumps from announcement to "Here's the new product!" | Acknowledge impact: "We understand this requires time to migrate" |
+| Terse or Defensive Tone | "Low usage forced us to shut down" | Be empathetic: "Consolidating to focus on the future" |
 
 ---
 
@@ -340,9 +280,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/eol-for-a-product-message.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `eol-message.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/positioning-statement/SKILL.md`, `skills/problem-statement/SKILL.md`, `skills/proto-persona/SKILL.md`

--- a/skills/epic-breakdown-advisor/SKILL.md
+++ b/skills/epic-breakdown-advisor/SKILL.md
@@ -18,8 +18,6 @@ scenarios:
 ## Purpose
 Guide product managers through breaking down epics into user stories using Richard Lawrence's complete Humanizing Work methodology—a systematic, flowchart-driven approach that applies 9 splitting patterns sequentially. Use this to identify which pattern applies, split while preserving user value, and evaluate splits based on what they reveal about low-value work you can eliminate. This ensures vertical slicing (end-to-end value) rather than horizontal slicing (technical layers).
 
-This is not arbitrary slicing—it's a proven, methodical process that starts with validation, walks through patterns in order, and evaluates results strategically.
-
 ## Key Concepts
 
 ### Core Principles: Vertical Slices Preserve Value
@@ -46,12 +44,6 @@ A user story is "a description of a change in system behavior from the perspecti
 2. List all variations
 3. Reduce variations to **one complete slice**
 4. Make other variations separate stories
-
-### Why This Works
-- **Prevents arbitrary splitting:** Methodical checklist prevents guessing
-- **Preserves user value:** Every story delivers observable value
-- **Reveals waste:** Good splits expose low-value work you can deprioritize
-- **Repeatable:** Apply to any epic consistently
 
 ---
 
@@ -575,57 +567,14 @@ Work through patterns in order. For each pattern, ask "Does this apply?"
 
 ## Common Pitfalls
 
-### Pitfall 1: Skipping Pre-Split Validation
-**Symptom:** Jump straight to splitting without checking INVEST
-
-**Consequence:** Split a story that shouldn't be split (e.g., not Valuable = technical task)
-
-**Fix:** Always run Step 1 (INVEST check) before Step 2 (splitting patterns)
-
----
-
-### Pitfall 2: Step-by-Step Workflow Splitting (Pattern 1 Done Wrong)
-**Symptom:** Story 1 = "Editorial review," Story 2 = "Legal approval"
-
-**Consequence:** Stories don't deliver end-to-end value
-
-**Fix:** Each story should cover **full workflow** (thin end-to-end slice), just with increasing sophistication
-
----
-
-### Pitfall 3: Horizontal Slicing (Technical Layers)
-**Symptom:** "Story 1: Build API. Story 2: Build UI."
-
-**Consequence:** Neither story delivers user value
-
-**Fix:** Vertical slicing—each story includes front-end + back-end to deliver observable user behavior
-
----
-
-### Pitfall 4: Forcing a Pattern That Doesn't Fit
-**Symptom:** "We'll split by workflow even though there's no sequence"
-
-**Consequence:** Arbitrary, meaningless split
-
-**Fix:** If pattern doesn't apply, say NO and continue to next pattern
-
----
-
-### Pitfall 5: Not Re-Splitting Large Stories
-**Symptom:** Split epic into 3 stories, but each is still 5+ days
-
-**Consequence:** Stories too large for sprint
-
-**Fix:** **Restart at Pattern 1** for each large story until all are 1-5 days
-
----
-
-### Pitfall 6: Ignoring Split Evaluation (Step 3)
-**Symptom:** Split but don't evaluate if it reveals low-value work
-
-**Consequence:** Miss opportunity to eliminate waste
-
-**Fix:** After splitting, ask: "Does this reveal work we can kill or defer?"
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Skipping Pre-Split Validation | Jump straight to splitting without INVEST check | Always run Step 1 (INVEST) before Step 2 (patterns) |
+| Step-by-Step Workflow Splitting | Story 1 = "Editorial review," Story 2 = "Legal approval" | Each story covers full workflow with increasing sophistication |
+| Horizontal Slicing | "Story 1: Build API. Story 2: Build UI." | Vertical slicing: each story delivers observable user behavior |
+| Forcing Wrong Pattern | "Split by workflow" when there's no sequence | If pattern doesn't apply, say NO and try next pattern |
+| Not Re-Splitting Large Stories | 3 stories but each still 5+ days | Restart at Pattern 1 for each large story until all 1-5 days |
+| Ignoring Split Evaluation | Split without checking for low-value work | Always ask: "Does this reveal work we can kill or defer?" |
 
 ---
 
@@ -657,9 +606,3 @@ Work through patterns in order. For each pattern, ask "Does this apply?"
 ### Sources
 - https://www.humanizingwork.com/the-humanizing-work-guide-to-splitting-user-stories/
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `epic-breakdown-advisor.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** Uses `user-story-splitting.md`, `user-story.md`, `epic-hypothesis.md`

--- a/skills/epic-hypothesis/SKILL.md
+++ b/skills/epic-hypothesis/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Frame epics as testable hypotheses using an if/then structure that articulates the action or solution, the target beneficiary, the expected outcome, and how you'll validate success. Use this to manage uncertainty in product development by making assumptions explicit, defining lightweight experiments ("tiny acts of discovery"), and establishing measurable success criteria before committing to full build-out.
 
-This is not a requirements spec—it's a hypothesis you're testing, not a feature you're committed to shipping.
-
 ## Key Concepts
 
 ### The Epic Hypothesis Framework
@@ -35,29 +33,11 @@ Inspired by Tim Herbig's Lean UX hypothesis format, the structure is:
   - [Qualitative measurable outcome]
   - [Add more as necessary]
 
-### Why This Structure Works
-- **Hypothesis-driven:** Forces you to state what you believe (and could be wrong about)
-- **Outcome-focused:** "Then we will" emphasizes user benefit, not feature output
-- **Experiment-first:** Encourages lightweight validation before full build
-- **Falsifiable:** Clear success criteria make it possible to kill bad ideas early
-- **Risk management:** Treats epics as bets, not commitments
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a feature spec:** "Build a dashboard with 5 charts" is a feature, not a hypothesis
 - **Not a guaranteed commitment:** Hypotheses can (and should) be invalidated
 - **Not output-focused:** "Ship feature X by Q2" misses the point—did it achieve the outcome?
 - **Not experiment-free:** If you skip experiments and go straight to build, you're not testing a hypothesis
-
-### When to Use This
-- Early-stage feature exploration (before committing to full roadmap)
-- Validating product-market fit for new capabilities
-- Prioritizing backlog (epics with validated hypotheses get higher priority)
-- Managing stakeholder expectations (frame work as experiments, not promises)
-
-### When NOT to Use This
-- For well-validated features (if you've already proven demand, skip straight to user stories)
-- For trivial features (don't over-engineer small tweaks)
-- When experiments aren't feasible (rare, but sometimes you must commit before testing)
 
 ---
 
@@ -202,48 +182,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Hypothesis is a Feature, Not an Outcome
-**Symptom:** "If we build a dashboard, then we will have a dashboard"
-
-**Consequence:** You're describing output, not outcome. This doesn't test anything.
-
-**Fix:** Focus on the user outcome: "If we build a dashboard showing real-time task status, then PMs will spend 50% less time asking for status updates."
-
----
-
-### Pitfall 2: Skipping Experiments
-**Symptom:** "We'll test our assumption by building the full feature"
-
-**Consequence:** You've committed to building before validating. Not a hypothesis—it's a feature commitment.
-
-**Fix:** Design lightweight experiments (prototypes, concierge tests, landing pages) that take days/weeks, not months.
-
----
-
-### Pitfall 3: Vague Validation Measures
-**Symptom:** "We know it's valid if users are happy"
-
-**Consequence:** Success criteria are subjective and unmeasurable.
-
-**Fix:** Define specific, falsifiable metrics: "80% of surveyed users rate the feature 4+ out of 5" or "Response time drops by 50%."
-
----
-
-### Pitfall 4: Unrealistic Timeframes
-**Symptom:** "We know it's valid if within 6 months revenue increases"
-
-**Consequence:** Too slow to inform decisions. By then, you've already built it.
-
-**Fix:** Aim for 2-4 week validation cycles. If you can't measure in that timeframe, choose a leading indicator (e.g., activation rate, not annual revenue).
-
----
-
-### Pitfall 5: Treating Epics as Commitments
-**Symptom:** "We already told the CEO we're shipping this, so we have to validate it"
-
-**Consequence:** Experiments are theater—you're going to build it regardless of results.
-
-**Fix:** Frame epics as hypotheses *before* making commitments. If stakeholders need certainty, explain the risk of building unvalidated features.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Hypothesis is a feature, not an outcome | "If we build a dashboard, then we will have a dashboard" | Focus on user outcome: "PMs will spend 50% less time asking for status updates" |
+| Skipping experiments | "We'll test our assumption by building the full feature" | Design lightweight experiments (prototypes, concierge tests) that take days/weeks, not months |
+| Vague validation measures | "We know it's valid if users are happy" | Define specific, falsifiable metrics: "80% rate it 4+ out of 5" or "Response time drops by 50%" |
+| Unrealistic timeframes | "We know it's valid if within 6 months revenue increases" | Aim for 2-4 week validation cycles. Use leading indicators (activation rate, not annual revenue) |
+| Treating epics as commitments | "We already told the CEO we're shipping this" | Frame epics as hypotheses *before* making commitments |
 
 ---
 

--- a/skills/executive-onboarding-playbook/SKILL.md
+++ b/skills/executive-onboarding-playbook/SKILL.md
@@ -16,14 +16,6 @@ scenarios:
 estimated_time: "20-30 min"
 ---
 
-## Purpose
-
-Structure the first 90 days of a VP or CPO transition as a diagnostic process, not an execution sprint. The single most common failure in senior product leadership transitions is acting before understanding — changing structures, replacing people, or announcing strategy before building the evidence base that makes those decisions defensible.
-
-This playbook runs in three phases: **Diagnose** (Month 1), **Validate** (Month 2), **Act with Evidence** (Month 3). Each phase builds on the last. Skipping phases doesn't accelerate results — it guarantees expensive reversals.
-
-This is not a 100-day plan for impressing your new boss. It's a diagnostic protocol for making durable decisions.
-
 ## Key Concepts
 
 ### The Consultant Mindset
@@ -219,48 +211,13 @@ See `examples/sample.md` for a full 30-60-90 diagnostic walkthrough with concret
 
 ## Common Pitfalls
 
-### Pitfall 1: Performing Action Instead of Building Evidence
-**Symptom:** Making structural announcements or process changes in Month 1 to signal decisive leadership
-
-**Consequence:** You build on incomplete understanding. Reversals in Month 3 damage credibility more than patience in Month 1 would have.
-
-**Fix:** Reframe patience as methodology, not passivity. "I'm in diagnostic mode for the first 30 days" is a confident statement when said clearly to your boss and team.
-
----
-
-### Pitfall 2: Staying in Consultant Mode Too Long
-**Symptom:** Still gathering information in Month 3; no visible actions or decisions
-
-**Consequence:** Organizational confidence erodes. People start to wonder if the new leader has opinions. Your boss starts to wonder if you can make decisions.
-
-**Fix:** Month 3 is the action phase. You won't have complete information — no one ever does. Act on your best current evidence and commit to learning from what follows.
-
----
-
-### Pitfall 3: Trusting the Loudest Voice
-**Symptom:** Forming early opinions based on the most vocal, most accessible, or most persuasive person you met in Month 1
-
-**Consequence:** You adopt one person's organizational narrative as ground truth. Decisions built on single-source information collapse when the rest of the organization provides context.
-
-**Fix:** Pattern-match across multiple independent conversations. Only act on themes you've heard from three or more unrelated sources.
-
----
-
-### Pitfall 4: Skipping the CEO Interview (Before Accepting)
-**Symptom:** Taking the CPO role without probing constraints, expectations, and talent assessment upfront
-
-**Consequence:** You walk into a situation where the roadmap is locked, the timeline is impossible, or the CEO's mental model of the team is so wrong that your first six months are spent managing their misperceptions instead of leading.
-
-**Fix:** The five questions in Phase 0 are not optional. Walk away from roles where the answers reveal fundamental misalignment. No role is worth a death march.
-
----
-
-### Pitfall 5: Ignoring Executive Dysfunction
-**Symptom:** Assuming that executive staff meetings will be mature, collaborative, and politics-free
-
-**Consequence:** You're blindsided by alliances, personal agendas, and interpersonal dynamics that operate beneath the surface of every executive team.
-
-**Fix:** Expect dysfunction. Patrick Lencioni's *Five Dysfunctions of a Team* applies to leadership teams as much as any other. Integrity gets tested more at higher levels, not less. Map the alliances in Month 1 as carefully as you map the product portfolio.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Performing action instead of building evidence | Making structural changes in Month 1 to signal decisiveness | Reframe patience as methodology: "I'm in diagnostic mode for 30 days" is a confident statement |
+| Staying in consultant mode too long | Still gathering information in Month 3, no visible actions | Month 3 is the action phase — act on your best current evidence and commit to learning |
+| Trusting the loudest voice | Forming opinions based on the most vocal person in Month 1 | Pattern-match across multiple independent conversations; act on themes from 3+ unrelated sources |
+| Skipping the CEO interview | Taking CPO role without probing constraints and expectations | The five Phase 0 questions are not optional — walk away from fundamental misalignment |
+| Ignoring executive dysfunction | Assuming exec meetings will be mature and politics-free | Expect dysfunction; map alliances in Month 1 as carefully as you map the product portfolio |
 
 ---
 

--- a/skills/feature-investment-advisor/SKILL.md
+++ b/skills/feature-investment-advisor/SKILL.md
@@ -19,8 +19,6 @@ scenarios:
 
 Guide product managers through evaluating whether to build a feature based on financial impact analysis. Use this to make data-driven prioritization decisions by assessing revenue connection (direct or indirect), cost structure (dev + COGS + OpEx), ROI calculation, and strategic value—then deliver actionable build/don't build recommendations with supporting math.
 
-This is not a generic prioritization framework—it's a financial lens for feature decisions that complements other prioritization methods (RICE, value vs. effort, user research). Use when financial impact is a key decision factor.
-
 ## Key Concepts
 
 ### The Feature Investment Framework
@@ -46,28 +44,6 @@ A systematic approach to evaluate features financially:
    - Platform enabler (unlocks future features)
    - Market positioning (needed for enterprise deals)
    - Risk reduction (compliance, security)
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not feature scoring alone:** Combines financial analysis with strategic judgment
-- **Not revenue-only thinking:** Considers margins, costs, and ROI, not just top-line revenue
-- **Not ignoring retention:** Indirect revenue impact (churn reduction) is equally valid
-- **Not building without validation:** Assumes you've done discovery; this is the financial lens
-
-### When to Use This Framework
-
-**Use this when:**
-- Prioritizing between features with quantifiable revenue/retention impact
-- Evaluating expensive features (>1 engineer-month of work)
-- Making build/buy/partner decisions
-- Defending feature prioritization to stakeholders or leadership
-- Choosing between direct monetization (add-on) vs. indirect (retention)
-
-**Don't use this when:**
-- Feature is table stakes (must-have for competitive parity)
-- Impact is purely qualitative (brand, UX delight without measurable retention effect)
-- You haven't validated the problem (do discovery first)
-- Feature is < 1 week of work (just build it)
 
 ---
 
@@ -529,93 +505,18 @@ See `examples/` folder for sample conversation flows. Mini examples below:
 
 ## Common Pitfalls
 
-### Pitfall 1: Confusing Revenue with Profit
-**Symptom:** "This feature will generate $1M in revenue!" (ignoring $800K COGS)
-
-**Consequence:** $1M revenue at 20% margin is worth $200K profit, not $1M. Feature looks great until you factor in costs.
-
-**Fix:** Always calculate contribution margin. Use `Revenue × Margin %`, not just revenue.
-
----
-
-### Pitfall 2: Ignoring Payback Period
-**Symptom:** "ROI is 5:1, let's build!" (but payback is 36 months and customers churn at 24 months)
-
-**Consequence:** You never recover the investment because customers leave before payback.
-
-**Fix:** Check payback period. Must be shorter than average customer lifetime.
-
----
-
-### Pitfall 3: Overestimating Adoption
-**Symptom:** "100% of customers will use this paid add-on!"
-
-**Consequence:** Real adoption is 10-20%. Revenue projections are 5-10x too high.
-
-**Fix:** Use conservative adoption estimates (10-20% for add-ons). Validate with willingness-to-pay research.
-
----
-
-### Pitfall 4: Building Without Validation
-**Symptom:** "We think this will reduce churn" (no customer interviews)
-
-**Consequence:** You build a feature that doesn't address real churn reasons. Churn stays flat.
-
-**Fix:** Interview churned customers first. Validate that this feature addresses top 3 churn reasons.
-
----
-
-### Pitfall 5: Ignoring Opportunity Cost
-**Symptom:** "This feature has 2:1 ROI, let's build!" (other features have 10:1 ROI)
-
-**Consequence:** You build a mediocre feature while better options sit in the backlog.
-
-**Fix:** Compare ROI across features. Build highest-ROI features first (unless strategic value overrides).
-
----
-
-### Pitfall 6: Strategic Value as Excuse
-**Symptom:** "ROI is terrible but it's strategic!" (no clear strategy)
-
-**Consequence:** "Strategic" becomes a catch-all for building low-value features.
-
-**Fix:** Define what "strategic" means (competitive moat, platform enabler, compliance). If it doesn't fit, it's not strategic.
-
----
-
-### Pitfall 7: Margin Dilution Blindness
-**Symptom:** "This feature adds $500K revenue!" (but COGS is $400K)
-
-**Consequence:** Your gross margin drops from 80% to 60%. Feature destroys unit economics.
-
-**Fix:** Calculate contribution margin. If margin is <50%, reconsider or charge a premium.
-
----
-
-### Pitfall 8: Celebrating Vanity Metrics
-**Symptom:** "This feature will increase engagement!" (but not revenue or retention)
-
-**Consequence:** You build features that feel good but don't impact business outcomes.
-
-**Fix:** Tie features to revenue or retention. Engagement is a leading indicator, not an outcome.
-
----
-
-### Pitfall 9: Forgetting Time Value of Money
-**Symptom:** "This feature pays back in 5 years"
-
-**Consequence:** $1 in 5 years is worth ~$0.65 today (at 9% discount rate). ROI is overstated.
-
-**Fix:** For long payback periods (>24 months), use NPV (net present value) to discount future cash flows.
-
----
-
-### Pitfall 10: Building Features for Loud Minorities
-**Symptom:** "50 customers requested this!" (out of 10,000)
-
-**Consequence:** You optimize for 0.5% of your base while ignoring the other 99.5%.
-
-**Fix:** Weight feature requests by revenue impact or customer segment. 10 enterprise customers > 100 SMB customers if enterprise is your strategy.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Confusing Revenue with Profit | "$1M revenue!" ignoring $800K COGS | Always calculate contribution margin: `Revenue x Margin %` |
+| Ignoring Payback Period | "ROI 5:1!" but 36-month payback, 24-month customer lifetime | Payback must be shorter than average customer lifetime |
+| Overestimating Adoption | "100% will use this add-on!" | Use conservative estimates (10-20%). Validate with WTP research |
+| Building Without Validation | "We think this reduces churn" — no interviews | Interview churned customers first. Validate top 3 churn reasons |
+| Ignoring Opportunity Cost | "2:1 ROI, let's build!" while 10:1 options exist | Compare ROI across features. Build highest-ROI first |
+| Strategic Value as Excuse | "ROI is bad but it's strategic!" | Define "strategic" concretely: moat, platform enabler, compliance |
+| Margin Dilution Blindness | "$500K revenue!" but $400K COGS | If margin <50%, reconsider or charge a premium |
+| Celebrating Vanity Metrics | "Increases engagement!" but not revenue/retention | Tie features to revenue or retention outcomes |
+| Forgetting Time Value of Money | "Pays back in 5 years" | Use NPV for payback >24 months |
+| Building for Loud Minorities | "50 requested this!" out of 10,000 | Weight by revenue impact/segment, not request count |
 
 ---
 

--- a/skills/finance-based-pricing-advisor/SKILL.md
+++ b/skills/finance-based-pricing-advisor/SKILL.md
@@ -19,12 +19,6 @@ scenarios:
 
 Evaluate the **financial impact** of pricing changes (price increases, new tiers, add-ons, discounts) using ARPU/ARPA analysis, conversion impact, churn risk, NRR effects, and CAC payback implications. Use this to make data-driven go/no-go decisions on proposed pricing changes with supporting math and risk assessment.
 
-**What this is:** Financial impact evaluation for pricing decisions you're already considering.
-
-**What this is NOT:** Comprehensive pricing strategy design, value-based pricing frameworks, willingness-to-pay research, competitive positioning, psychological pricing, packaging architecture, or monetization model selection. For those topics, see the future `pricing-strategy-suite` skills.
-
-This skill assumes you have a specific pricing change in mind and need to evaluate its financial viability.
-
 ## Key Concepts
 
 ### The Pricing Impact Framework
@@ -73,29 +67,6 @@ A systematic approach to evaluate pricing changes financially:
 - Feature bundling (combine features into tiers)
 - Unbundling (separate features into add-ons)
 - Pricing metric change (seats → usage, or vice versa)
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not value-based pricing:** This evaluates a proposed change, not "what should we charge?"
-- **Not WTP research:** This analyzes impact, not "what will customers pay?"
-- **Not competitive positioning:** This is financial analysis, not market positioning
-- **Not packaging architecture:** This evaluates one change, not redesigning all tiers
-
-### When to Use This Framework
-
-**Use this when:**
-- You have a specific pricing change to evaluate (e.g., "Should we raise prices 20%?")
-- You need to quantify revenue, churn, and conversion trade-offs
-- You're deciding between pricing change options (test A vs. B)
-- You need to present pricing change impact to leadership or board
-
-**Don't use this when:**
-- You're designing pricing strategy from scratch (use value-based pricing frameworks)
-- You haven't validated willingness-to-pay (do customer research first)
-- You don't have baseline metrics (ARPU, churn, conversion rates)
-- Change is too small to matter (<5% price change, <10% of customers affected)
-
----
 
 ### Facilitation Source of Truth
 
@@ -641,93 +612,18 @@ See `examples/` folder for sample conversation flows. Mini examples below:
 
 ## Common Pitfalls
 
-### Pitfall 1: Ignoring Churn Impact
-**Symptom:** "We'll raise prices 30% and make $X more!" (no churn modeling)
-
-**Consequence:** Churn wipes out revenue gains. Net impact negative.
-
-**Fix:** Model churn scenarios (conservative, base, optimistic). Factor churn-driven revenue loss into net impact.
-
----
-
-### Pitfall 2: Not Grandfathering Existing Customers
-**Symptom:** "We're raising prices for everyone effective immediately"
-
-**Consequence:** Massive churn spike from existing customers who feel betrayed.
-
-**Fix:** Grandfather existing customers. Raise prices for new customers only.
-
----
-
-### Pitfall 3: Testing Without Statistical Power
-**Symptom:** "We tested on 10 customers and it worked!"
-
-**Consequence:** 10 customers isn't statistically significant. Results are noise.
-
-**Fix:** Test with large enough sample (100+ customers per cohort) for 60-90 days.
-
----
-
-### Pitfall 4: Pricing Changes Without Value Justification
-**Symptom:** "We're raising prices because we need more revenue"
-
-**Consequence:** Customers see price increase without corresponding value increase. Churn.
-
-**Fix:** Tie price increases to value improvements (new features, better support, outcomes delivered).
-
----
-
-### Pitfall 5: Ignoring CAC Payback Impact
-**Symptom:** "Higher ARPU is always better!"
-
-**Consequence:** If conversion drops 30%, effective CAC increases dramatically. Payback period explodes.
-
-**Fix:** Calculate CAC payback impact. Higher ARPU with lower conversion might make payback worse, not better.
-
----
-
-### Pitfall 6: Annual Discounts That Hurt Margin
-**Symptom:** "30% discount for annual prepay!" (improves cash but destroys LTV)
-
-**Consequence:** Customers lock in low prices for a year. Revenue per customer decreases.
-
-**Fix:** Limit annual discounts to 10-15%. Balance cash flow improvement with LTV protection.
-
----
-
-### Pitfall 7: Copycat Pricing (Competitor-Based)
-**Symptom:** "Competitor raised prices, so should we"
-
-**Consequence:** Your customers, value prop, and cost structure are different. What works for them may not work for you.
-
-**Fix:** Use competitors as data points, not decisions. Make pricing decisions based on your unit economics.
-
----
-
-### Pitfall 8: Premature Optimization
-**Symptom:** "Let's A/B test 47 different price points!"
-
-**Consequence:** Analysis paralysis. Spending months on 5% pricing optimizations while missing 50% growth opportunities elsewhere.
-
-**Fix:** Big pricing changes (tiers, packaging, add-ons) matter more than micro-optimizations. Start there.
-
----
-
-### Pitfall 9: Forgetting Expansion Revenue
-**Symptom:** "We're maximizing ARPU at acquisition"
-
-**Consequence:** High upfront pricing prevents landing customers. Miss expansion opportunities.
-
-**Fix:** Consider "land and expand" strategy. Lower entry price, higher expansion revenue via upsells.
-
----
-
-### Pitfall 10: No Pricing Change Communication Plan
-**Symptom:** "We're raising prices next month" (no customer communication)
-
-**Consequence:** Surprised customers churn. Poor reviews. Reputation damage.
-
-**Fix:** Communicate pricing changes 30-60 days in advance. Emphasize value, not just price.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Ignoring churn impact** | "Raise prices 30% and make $X more!" (no churn modeling) | Model churn scenarios; factor churn-driven revenue loss into net impact |
+| **Not grandfathering existing customers** | Raising prices for everyone immediately | Grandfather existing customers; raise for new customers only |
+| **Testing without statistical power** | "Tested on 10 customers and it worked!" | 100+ customers per cohort for 60-90 days minimum |
+| **No value justification** | "Raising prices because we need more revenue" | Tie increases to value improvements (features, support, outcomes) |
+| **Ignoring CAC payback impact** | "Higher ARPU is always better!" | Calculate payback impact; higher ARPU + lower conversion may worsen payback |
+| **Annual discounts that hurt margin** | 30% discount for annual prepay | Limit annual discounts to 10-15%; balance cash flow with LTV protection |
+| **Copycat pricing** | "Competitor raised prices, so should we" | Use competitors as data points, not decisions; base on your unit economics |
+| **Premature optimization** | A/B testing 47 price points | Big changes (tiers, packaging) matter more than micro-optimizations |
+| **Forgetting expansion revenue** | Maximizing ARPU at acquisition | Consider "land and expand": lower entry, higher expansion via upsells |
+| **No communication plan** | "Raising prices next month" (no notice) | Communicate 30-60 days in advance; emphasize value, not just price |
 
 ---
 

--- a/skills/finance-metrics-quickref/SKILL.md
+++ b/skills/finance-metrics-quickref/SKILL.md
@@ -19,33 +19,7 @@ scenarios:
 
 Quick reference for any SaaS finance metric without deep teaching. Use this when you need a fast formula lookup, benchmark check, or decision framework reminder. For detailed explanations, calculations, and examples, see the related deep-dive skills.
 
-This is not a teaching tool—it's a cheat sheet optimized for speed. Scan, find, apply.
-
 ## Key Concepts
-
-### Metric Categories
-
-Metrics are organized into four families:
-
-1. **Revenue & Growth** — Top-line money (revenue, ARPU, ARPA, MRR/ARR, churn, NRR, expansion)
-2. **Unit Economics** — Customer-level profitability (CAC, LTV, payback, margins)
-3. **Capital Efficiency** — Cash management (burn rate, runway, OpEx, net income)
-4. **Efficiency Ratios** — Growth vs. profitability balance (Rule of 40, magic number)
-
-### When to Use This Skill
-
-**Use this when:**
-- You need a quick formula or benchmark
-- You're preparing for a board meeting or investor call
-- You're evaluating a decision and need to check which metrics matter
-- You want to identify red flags quickly
-
-**Don't use this when:**
-- You need detailed calculation guidance (use `saas-revenue-growth-metrics` or `saas-economics-efficiency-metrics`)
-- You're learning these metrics for the first time (start with deep-dive skills)
-- You need examples and common pitfalls (covered in related skills)
-
----
 
 ## Application
 

--- a/skills/jobs-to-be-done/SKILL.md
+++ b/skills/jobs-to-be-done/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Systematically explore what customers are trying to accomplish (functional, social, emotional jobs), the pains they experience, and the gains they seek. Use this framework to uncover unmet needs, validate product ideas, and ensure your solution addresses real motivations—not just surface-level feature requests.
 
-This is not a survey—it's a structured lens for understanding *why* customers "hire" your product and what would make them "fire" it.
-
 ## Key Concepts
 
 ### The Jobs-to-be-Done Framework
@@ -33,32 +31,6 @@ Influenced by Clayton Christensen and the Value Proposition Canvas (Osterwalder)
 - **Savings:** Time, money, or effort reductions that delight
 - **Adoption factors:** What increases likelihood of switching
 - **Life improvement:** How a solution makes life easier or more enjoyable
-
-### Why This Structure Works
-- **Separates job from solution:** "Communicate with my team" (job) ≠ "email" (solution)
-- **Reveals underlying motivations:** Functional job may be "track expenses," but emotional job is "feel in control of finances"
-- **Surfaces competition you didn't see:** Customers "hire" non-obvious alternatives (pen and paper, spreadsheets, workarounds)
-- **Prioritizes by intensity:** Not all pains are equal—focus on the most acute
-
-### Anti-Patterns (What This Is NOT)
-- **Not a feature wishlist:** "I want AI, automation, and dashboards" is not a job
-- **Not demographics:** "Millennials want mobile-first" is a persona trait, not a job
-- **Not generic:** "Be more productive" is too vague—dig into *which* tasks and *why*
-- **Not one-dimensional:** Focusing only on functional jobs misses social/emotional motivations
-
-### When to Use This
-- Early-stage discovery (before you know the solution)
-- Validating product-market fit (does your solution address the right jobs?)
-- Prioritizing roadmap (which jobs are most painful/important?)
-- Competitive analysis (what are customers "hiring" competitors for?)
-- Marketing messaging (speak to jobs, not features)
-
-### When NOT to Use This
-- After you've already built the product (too late for discovery)
-- For trivial features (don't over-analyze small tweaks)
-- As a substitute for quantitative validation (JTBD informs hypotheses; data validates them)
-
----
 
 ## Application
 
@@ -298,48 +270,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Confusing Jobs with Solutions
-**Symptom:** "I need to use Slack" or "I need AI-powered analytics"
-
-**Consequence:** You've anchored on a solution, not the underlying job.
-
-**Fix:** Ask "Why?" 5 times. "I need Slack" → "Why?" → "To communicate with my team" → "Why?" → "To get quick answers" → "Why?" → "To avoid project delays."
-
----
-
-### Pitfall 2: Generic Jobs
-**Symptom:** "Be more productive" or "Save time"
-
-**Consequence:** Too vague to inform product decisions.
-
-**Fix:** Get specific. "Save time" → "Reduce time spent generating monthly reports from 8 hours to 1 hour."
-
----
-
-### Pitfall 3: Ignoring Social/Emotional Jobs
-**Symptom:** Only documenting functional jobs
-
-**Consequence:** You miss powerful motivators. People often buy based on emotional/social needs, not just functional.
-
-**Fix:** Explicitly ask about perception and emotions in interviews. "How would solving this make you feel?" "Who would notice if you solved this?"
-
----
-
-### Pitfall 4: Fabricating JTBD Without Research
-**Symptom:** Filling out the template based on assumptions
-
-**Consequence:** You're guessing. JTBD analysis is only valuable if grounded in real customer insights.
-
-**Fix:** Conduct "switch interviews" (ask why they switched from a previous solution), contextual inquiries, or problem validation interviews.
-
----
-
-### Pitfall 5: Treating All Pains as Equal
-**Symptom:** Listing 20 pains without prioritization
-
-**Consequence:** No clarity on what to solve first.
-
-**Fix:** Rank pains by intensity (acute vs. mild). Ask "If we only solved one pain, which would have the biggest impact?"
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Confusing jobs with solutions** | "I need Slack" or "I need AI analytics" | Ask "Why?" 5 times until you reach the underlying job |
+| **Generic jobs** | "Be more productive" or "Save time" | Get specific: "Reduce monthly report generation from 8 hours to 1 hour" |
+| **Ignoring social/emotional jobs** | Only documenting functional jobs | Ask "How would solving this make you feel?" and "Who would notice?" |
+| **Fabricating JTBD without research** | Filling template based on assumptions | Conduct switch interviews, contextual inquiries, or problem validation interviews |
+| **Treating all pains as equal** | Listing 20 pains without prioritization | Rank by intensity: "If we only solved one pain, which has the biggest impact?" |
 
 ---
 
@@ -361,10 +298,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/jobs-to-be-done.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `jobs-to-be-done.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/proto-persona/SKILL.md`
-**Used by:** `skills/positioning-statement/SKILL.md`, `skills/problem-statement/SKILL.md`, `skills/epic-hypothesis/SKILL.md`

--- a/skills/lean-ux-canvas/SKILL.md
+++ b/skills/lean-ux-canvas/SKILL.md
@@ -18,8 +18,6 @@ scenarios:
 
 Guide product managers through creating **Jeff Gothelf's Lean UX Canvas (v2)**—a one-page facilitation tool that frames work around a **business problem to solve**, not a **solution to implement**. Use this to align cross-functional teams around core assumptions, craft testable hypotheses, and ensure learning happens every sprint by exposing gaps in understanding (problem, users, value, and why the solution should work).
 
-This is not a roadmap or feature list—it's an **"insurance policy"** that turns assumptions into experiments before committing to full development. The canvas shifts conversations from **outputs** to **outcomes** and ensures teams build the right thing, not just build things right.
-
 ## Key Concepts
 
 ### What is the Lean UX Canvas?
@@ -67,25 +65,7 @@ The **Lean UX Canvas (v2)** is a structured, one-page template designed to help 
 7. **What's Most Important to Learn First?** — The single riskiest assumption right now
 8. **What's the Least Work to Learn Next?** — Smallest experiment to validate/invalidate that assumption
 
----
-
-### Why This Works
-
-**Problem-First, Not Solution-First:**
-Starts with "what changed in the world?" not "we should build X." This prevents solution-driven thinking.
-
-**Assumption-Driven:**
-Makes hypotheses explicit before building. Every discipline surfaces their risks (technical feasibility, user value, business viability).
-
-**Experiment-Focused:**
-Tests assumptions before committing resources. Small experiments beat big bets.
-
-**Cross-Functional Alignment:**
-Shared canvas creates common language. Everyone sees the same gaps in understanding.
-
----
-
-### Key Distinctions (Avoid Confusion)
+### Key Distinctions
 
 **Box 2 (Business Outcomes) vs. Box 4 (User Outcomes):**
 - **Box 2:** Measurable **behavior change** (retention rate, time on site, average order value)
@@ -98,31 +78,6 @@ List candidate solutions (features, policies, even business model shifts). You'r
 
 **Hypotheses (Box 6) Are Testable:**
 Use the template: "We believe [business outcome] will be achieved if [user] attains [benefit] with [solution]." Each hypothesis focuses on **one** solution.
-
----
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not a feature list:** Solutions are ideas to test, not a backlog
-- **Not a project plan:** Canvas frames learning, not delivery timelines
-- **Not a replacement for strategy:** Canvas executes strategy; it doesn't create it
-- **Not a one-time exercise:** Re-visit as you learn; update assumptions
-
----
-
-### When to Use This
-
-✅ **Use this when:**
-- Starting a new product initiative or feature
-- Reframing an existing project (suspect you're building the wrong thing)
-- Aligning cross-functional teams on assumptions and experiments
-- Planning discovery sprints or MVPs
-- Stakeholders are solution-driven ("we need to build X") and you need to expose assumptions
-
-❌ **Don't use this when:**
-- Problem and solution are already validated (move to execution)
-- Tactical bug fixes or technical debt (no learning needed)
-- Stakeholders have committed to a solution regardless of evidence (address alignment first)
 
 ---
 
@@ -485,57 +440,14 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### 1. **Starting with Solutions, Not Problems**
-**Failure Mode:** Box 1 says "We need to build X" instead of describing what changed.
-
-**Consequence:** You build the solution someone already decided on, without validating the problem exists.
-
-**Fix:** Ask: "What changed in the world? Why is this a problem now (vs. 6 months ago)?"
-
----
-
-### 2. **Vague Business Outcomes**
-**Failure Mode:** Box 2 says "Increase revenue" or "Make users happy."
-
-**Consequence:** No way to measure success; can't tell if experiments worked.
-
-**Fix:** Define measurable behavior change. "Increase average order value from $50 to $75" or "Reduce support tickets by 30%."
-
----
-
-### 3. **Too-Broad User Segments**
-**Failure Mode:** Box 3 says "All users" or "Everyone."
-
-**Consequence:** Can't design targeted experiments; waste time on personas who won't adopt.
-
-**Fix:** Pick one persona to start. You can expand later.
-
----
-
-### 4. **Confusing Box 2 and Box 4**
-**Failure Mode:** Putting emotions in Box 2 and metrics in Box 4 (or vice versa).
-
-**Consequence:** Misaligned hypotheses; unclear success criteria.
-
-**Fix:** **Box 2 = Behavior change (metrics).** **Box 4 = Goals, benefits, emotions (empathy).**
-
----
-
-### 5. **Only One Solution in Box 5**
-**Failure Mode:** Listing one feature because stakeholders already decided.
-
-**Consequence:** No exploration of alternatives; can't test which solution is best.
-
-**Fix:** Force yourself to list 3+ solutions. Ask: "What else could solve this problem?"
-
----
-
-### 6. **Skipping Experiments (Box 8)**
-**Failure Mode:** "We'll just build it and see what happens."
-
-**Consequence:** Waste weeks/months building the wrong thing.
-
-**Fix:** Design smallest experiment first. If you can't think of one, use `skills/pol-probe-advisor/SKILL.md` to choose a validation method.
+| Pitfall | Failure Mode | Fix |
+|---------|-------------|-----|
+| **Starting with solutions** | Box 1 says "We need to build X" | Ask: "What changed? Why is this a problem now vs. 6 months ago?" |
+| **Vague business outcomes** | Box 2 says "Increase revenue" or "Make users happy" | Define measurable behavior change (e.g., "AOV $50 to $75") |
+| **Too-broad user segments** | Box 3 says "All users" or "Everyone" | Pick one persona to start; expand later |
+| **Confusing Box 2 and Box 4** | Emotions in Box 2, metrics in Box 4 | Box 2 = behavior change (metrics); Box 4 = goals/benefits/emotions |
+| **Only one solution in Box 5** | One feature because stakeholders decided | List 3+ solutions; ask "What else could solve this?" |
+| **Skipping experiments** | "We'll just build it and see" | Design smallest experiment first; use `pol-probe-advisor` if stuck |
 
 ---
 

--- a/skills/opportunity-solution-tree/SKILL.md
+++ b/skills/opportunity-solution-tree/SKILL.md
@@ -10,8 +10,6 @@ type: interactive
 ## Purpose
 Guide product managers through creating an Opportunity Solution Tree (OST) by extracting target outcomes from stakeholder requests, generating opportunity options (problems to solve), mapping potential solutions, and selecting the best proof-of-concept (POC) based on feasibility, impact, and market fit. Use this to move from vague product requests to structured discovery, ensuring teams solve the right problems before jumping to solutions—avoiding "feature factory" syndrome and premature convergence on ideas.
 
-This is not a roadmap generator—it's a structured discovery process that outputs validated opportunities with testable solution hypotheses.
-
 ## Key Concepts
 
 ### What is an Opportunity Solution Tree (OST)?
@@ -34,33 +32,6 @@ Opportunity  Opportunity  Opportunity (3)
   | | |       | | |       | | |
  S1 S2 S3    S1 S2 S3    S1 S2 S3 (9 total solutions)
 ```
-
-### Why This Works
-- **Outcome-driven:** Starts with business goal, not feature requests
-- **Divergent before convergent:** Explores multiple opportunities before picking solutions
-- **Problem-focused:** Opportunities are problems, not solutions disguised as problems
-- **Testable:** Each solution maps to experiments, not just "build it and ship"
-- **POC selection:** Evaluates feasibility, impact, market fit before committing resources
-
-### Anti-Patterns (What This Is NOT)
-- **Not a feature list:** Opportunities are problems customers face, not "we need dark mode"
-- **Not solution-first:** Don't start with "we should build X"—start with "customers struggle with Y"
-- **Not waterfall planning:** OST is a discovery tool, not a project plan
-- **Not a one-time exercise:** OSTs evolve as you learn from experiments
-
-### When to Use This
-- Stakeholder requests a feature or product initiative
-- Starting discovery for a new product area
-- Clarifying vague OKRs or strategic goals
-- Prioritizing which problems to solve first
-- Aligning team on what outcomes you're driving
-
-### When NOT to Use This
-- When the problem is already validated (move to solution testing)
-- For tactical bug fixes or technical debt (no discovery needed)
-- When stakeholders demand a specific solution (address alignment issues first)
-
----
 
 ### Facilitation Source of Truth
 
@@ -349,48 +320,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Opportunities Disguised as Solutions
-**Symptom:** "Opportunity: We need a mobile app"
-
-**Consequence:** You've already converged on a solution without exploring the problem.
-
-**Fix:** Reframe opportunities as customer problems: "Mobile-first users can't access product on the go."
-
----
-
-### Pitfall 2: Skipping Divergence (Jumping to One Solution)
-**Symptom:** "We know the solution is [X], just need to build it"
-
-**Consequence:** Miss better alternatives, no learning.
-
-**Fix:** Generate at least 3 solutions per opportunity. Force divergence before convergence.
-
----
-
-### Pitfall 3: Outcome is Too Vague
-**Symptom:** "Desired Outcome: Improve user experience"
-
-**Consequence:** Can't measure success, can't prioritize opportunities.
-
-**Fix:** Make outcomes measurable: "Increase NPS from 30 to 50" or "Reduce onboarding drop-off from 60% to 40%."
-
----
-
-### Pitfall 4: No Experiments (Just Build It)
-**Symptom:** Picking a solution and moving straight to roadmap
-
-**Consequence:** No validation, high risk of building wrong thing.
-
-**Fix:** Every solution must map to an experiment. No experiments = no OST.
-
----
-
-### Pitfall 5: Analysis Paralysis (Exploring Forever)
-**Symptom:** Generating 20 opportunities, 50 solutions, never picking one
-
-**Consequence:** Team stuck in discovery, no progress.
-
-**Fix:** Limit to 3 opportunities, 3 solutions each (9 total). Pick POC, run experiment, learn, iterate.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Opportunities disguised as solutions** | "Opportunity: We need a mobile app" | Reframe as customer problems: "Mobile-first users can't access product on the go" |
+| **Skipping divergence** | "We know the solution, just need to build it" | Generate at least 3 solutions per opportunity before converging |
+| **Outcome too vague** | "Improve user experience" | Make measurable: "Increase NPS from 30 to 50" or "Reduce drop-off 60% to 40%" |
+| **No experiments** | Picking a solution, moving straight to roadmap | Every solution must map to an experiment; no experiments = no OST |
+| **Analysis paralysis** | 20 opportunities, 50 solutions, never picking one | Limit to 3 opportunities, 3 solutions each; pick POC and run experiment |
 
 ---
 
@@ -412,9 +348,3 @@ Mini example excerpt:
 - Productside Blueprint — Strategic product discovery process
 - [If Dean has OST resources, link here]
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `opportunity-solution-tree.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** Uses `skills/problem-statement/SKILL.md`, `skills/jobs-to-be-done/SKILL.md`, `skills/epic-hypothesis/SKILL.md`, `skills/user-story/SKILL.md`

--- a/skills/pestel-analysis/SKILL.md
+++ b/skills/pestel-analysis/SKILL.md
@@ -7,11 +7,6 @@ type: component
 ---
 
 
-## Purpose
-Conduct a systematic analysis of macro-environmental factors—Political, Economic, Social, Technological, Environmental, and Legal—that could impact your product or project. Use this to identify external opportunities and threats, inform strategic planning, assess market entry risks, and make data-driven decisions about product direction in the context of broader forces beyond your control.
-
-This is not internal analysis—it's outward-facing assessment of the big-picture forces shaping your product's environment.
-
 ## Key Concepts
 
 ### The PESTEL Framework
@@ -23,29 +18,6 @@ Originating from Francis Joseph Aguilar's 1967 PEST analysis, PESTEL extends the
 4. **Technological:** Advancements, R&D, automation, digital transformation
 5. **Environmental:** Climate change, sustainability, resource scarcity, regulations
 6. **Legal:** Compliance, IP rights, employment laws, health/safety regulations
-
-### Why This Works
-- **Comprehensive:** Covers all major external forces affecting your product
-- **Proactive:** Identifies threats and opportunities before they become critical
-- **Strategic:** Informs long-term planning, not just tactical decisions
-- **Risk management:** Highlights vulnerabilities in your product strategy
-
-### Anti-Patterns (What This Is NOT)
-- **Not competitive analysis:** PESTEL looks at macro factors, not competitors
-- **Not internal analysis:** Focuses on external environment, not your company's strengths/weaknesses
-- **Not static:** Macro environment changes—reassess regularly
-
-### When to Use This
-- Entering a new market or geography
-- Strategic planning (annual roadmapping, 3-5 year planning)
-- Assessing product viability in a changing environment
-- Risk assessment for new product initiatives
-- Pitching to execs or investors (shows environmental awareness)
-
-### When NOT to Use This
-- For tactical, short-term decisions (use competitive analysis instead)
-- When external factors are stable and well-understood
-- As a substitute for customer research (PESTEL is macro, not micro)
 
 ---
 
@@ -305,48 +277,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Generic Analysis
-**Symptom:** "Political: Regulations exist. Economic: Economy affects spending."
-
-**Consequence:** No actionable insights.
-
-**Fix:** Be specific: "EU AI Act requires explainable AI → Need transparency features by Q3 2026."
-
----
-
-### Pitfall 2: Ignoring Low-Impact Factors
-**Symptom:** Forcing relevance where none exists (e.g., "Climate change affects our SaaS product...")
-
-**Consequence:** Wastes time, dilutes focus.
-
-**Fix:** If a factor has low impact, say so. Focus effort on high-impact areas.
-
----
-
-### Pitfall 3: No Data Sources
-**Symptom:** "Economic growth is strong" (no citation)
-
-**Consequence:** Unverifiable claims, low credibility.
-
-**Fix:** Cite sources: "SMB sector growing 5% annually (US Census Bureau, 2025)."
-
----
-
-### Pitfall 4: Analysis Without Action
-**Symptom:** Long list of factors, no strategic recommendations
-
-**Consequence:** Insights don't inform decisions.
-
-**Fix:** Synthesize into "Top Opportunities," "Top Threats," and "Strategic Recommendations."
-
----
-
-### Pitfall 5: One-Time Exercise
-**Symptom:** PESTEL analysis done once, never revisited
-
-**Consequence:** Stale insights as macro environment shifts.
-
-**Fix:** Review annually or when major external events occur (new regulations, economic shifts, etc.).
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Generic analysis | "Political: Regulations exist" | Be specific: "EU AI Act requires explainable AI → Need transparency features by Q3 2026" |
+| Forcing low-impact factors | "Climate change affects our SaaS product..." | If impact is minimal, say so — focus effort on high-impact areas |
+| No data sources | "Economic growth is strong" (no citation) | Cite sources: "SMB sector growing 5% annually (US Census Bureau, 2025)" |
+| Analysis without action | Long list of factors, no recommendations | Synthesize into Top Opportunities, Top Threats, and Strategic Recommendations |
+| One-time exercise | PESTEL done once, never revisited | Review annually or when major external events occur |
 
 ---
 
@@ -368,9 +305,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/pestel-analysis-prompt-template.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `pestel-analysis.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/recommendation-canvas/SKILL.md`, `skills/positioning-statement/SKILL.md`

--- a/skills/pol-probe-advisor/SKILL.md
+++ b/skills/pol-probe-advisor/SKILL.md
@@ -16,9 +16,7 @@ scenarios:
 
 ## Purpose
 
-Guide product managers through selecting the right **Proof of Life (PoL) probe** type (of 5 flavors) based on their hypothesis, risk, and available resources. Use this when you need to eliminate a specific risk or test a narrow hypothesis, but aren't sure which validation method to use. This interactive skill ensures you match the cheapest prototype to the harshest truth—not the prototype you're most comfortable building.
-
-This is **not** a tool for deciding *if* you should validate (you should). It's a decision framework for choosing *how* to validate most effectively.
+Guide product managers through selecting the right **Proof of Life (PoL) probe** based on hypothesis, risk, and available resources. Matches the cheapest prototype to the harshest truth — not the prototype you're most comfortable building.
 
 ## Key Concepts
 
@@ -41,31 +39,6 @@ This is **not** a tool for deciding *if* you should validate (you should). It's 
 | **Vibe-Coded PoL Probe** | "Will this solution survive real user contact?" | Workflow/UX validation with real interactions | 2-3 days |
 
 **Golden Rule:** *"Use the cheapest prototype that tells the harshest truth."*
-
----
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not "build the prototype you're comfortable with":** Match method to hypothesis, not skillset
-- **Not "pick based on stakeholder preference":** Optimize for learning, not internal politics
-- **Not "choose the most impressive option":** Impressive ≠ informative
-- **Not "default to code":** Writing code should be your last resort, not your first
-
----
-
-### When to Use This Skill
-
-✅ **Use this when:**
-- You have a clear hypothesis but don't know which validation method to use
-- You're unsure whether to build code, create a video, or run a simulation
-- You need to eliminate a specific risk quickly (within days)
-- You want to avoid prototype theater
-
-❌ **Don't use this when:**
-- You don't have a hypothesis yet (use `problem-statement.md` or `problem-framing-canvas.md` first)
-- You're trying to impress executives (that's not validation)
-- You already know the answer (confirmation bias)
-- You need to ship an MVP (this is for pre-MVP reconnaissance)
 
 ---
 
@@ -425,48 +398,13 @@ If executives need a demo, build it *after* you've validated the hypothesis with
 
 ## Common Pitfalls
 
-### 1. **Choosing Based on Tooling Comfort**
-**Failure Mode:** "I know Figma, so I'll design a UI prototype" (even if design isn't the risk).
-
-**Consequence:** Validate the wrong thing; miss the actual risk.
-
-**Fix:** Answer the core question *first*, then pick the method. If you need a Feasibility Check but only know design tools, pair with an engineer for 1 day.
-
----
-
-### 2. **Defaulting to Code**
-**Failure Mode:** "Let's just build it and see what happens."
-
-**Consequence:** 2 weeks of development before learning you tested the wrong hypothesis.
-
-**Fix:** Ask: "What's the cheapest prototype that tells the harshest truth?" Usually it's NOT code.
-
----
-
-### 3. **Confusing Vibe-Coded Probes with MVPs**
-**Failure Mode:** Vibe-Coded probe "looks real," so team treats it like production code.
-
-**Consequence:** Scope creep, technical debt, resistance to disposal.
-
-**Fix:** Set disposal date before building. Vibe-Coded probes are **Frankensoft by design**—celebrate the jank, delete after learning.
-
----
-
-### 4. **Testing Multiple Things at Once**
-**Failure Mode:** "Let's test the workflow, the pricing, and the UI in one probe."
-
-**Consequence:** Ambiguous results—you won't know which variable caused failure.
-
-**Fix:** One probe, one hypothesis. If you have 3 hypotheses, run 3 probes.
-
----
-
-### 5. **Skipping Success Criteria**
-**Failure Mode:** "We'll know it when we see it."
-
-**Consequence:** No harsh truth—just opinions and vanity metrics.
-
-**Fix:** Write success criteria *before* building. Define "pass," "fail," and "learn" thresholds.
+| Pitfall | Failure Mode | Fix |
+|---------|-------------|-----|
+| Choosing based on tooling comfort | "I know Figma, so I'll design a UI prototype" (even if design isn't the risk) | Answer the core question *first*, then pick the method |
+| Defaulting to code | "Let's just build it and see what happens" | Ask: "What's the cheapest prototype that tells the harshest truth?" Usually it's NOT code |
+| Confusing vibe-coded probes with MVPs | Probe "looks real," team treats it as production code | Set disposal date before building — celebrate the jank, delete after learning |
+| Testing multiple things at once | "Let's test workflow, pricing, and UI in one probe" | One probe, one hypothesis. 3 hypotheses = 3 probes |
+| Skipping success criteria | "We'll know it when we see it" | Write pass/fail/learn thresholds *before* building |
 
 ---
 

--- a/skills/pol-probe/SKILL.md
+++ b/skills/pol-probe/SKILL.md
@@ -14,21 +14,7 @@ scenarios:
   - "Create a low-cost validation probe before we build this feature"
 ---
 
-## Purpose
-
-Define and document a **Proof of Life (PoL) probe**—a lightweight, disposable validation artifact designed to surface harsh truths before expensive development. Use this when you need to eliminate a specific risk or test a narrow hypothesis **without building production-quality software**. PoL probes are reconnaissance missions, not MVPs—they're meant to be deleted, not scaled.
-
-This framework prevents prototype theater (expensive demos that impress stakeholders but teach nothing) and forces you to match validation method to actual learning goal.
-
 ## Key Concepts
-
-### What is a PoL Probe?
-
-A **Proof of Life (PoL) probe** is a deliberate, disposable validation experiment designed to answer one specific question as cheaply and quickly as possible. It's not a product, not an MVP, not a pilot—it's a targeted truth-seeking mission.
-
-**Origin:** Coined by Dean Peters (Productside), building on Marty Cagan's 2014 work on prototype flavors and Jeff Patton's principle: *"The most expensive way to test your idea is to build production-quality software."*
-
----
 
 ### The 5 Essential Characteristics
 
@@ -74,24 +60,6 @@ Match the probe type to your hypothesis, not your tooling comfort.
 | **5. Vibe-Coded PoL Probes** | "Will this solution survive real user contact?" | 2-3 days | ChatGPT Canvas + Replit + Airtable = "Frankensoft" | You need user feedback on workflow/UX, but not production-grade code |
 
 **Golden Rule:** *"Use the cheapest prototype that tells the harshest truth. If it doesn't sting, it's probably just theater."*
-
----
-
-### When to Use a PoL Probe
-
-✅ **Use a PoL probe when:**
-- You have a specific, falsifiable hypothesis to test
-- A particular risk blocks your next decision (technical feasibility, user task completion, stakeholder support)
-- You need harsh truth fast (within days, not weeks)
-- Building production software would be premature or wasteful
-- You can articulate what "failure" looks like before you start
-
-❌ **Don't use a PoL probe when:**
-- You're trying to impress executives (that's prototype theater)
-- You already know the answer and just want validation (that's confirmation bias)
-- You can't articulate a clear hypothesis or disposal plan
-- The learning goal is too broad ("Will customers like this?")
-- You're using it to avoid making a hard decision
 
 ---
 

--- a/skills/positioning-statement/SKILL.md
+++ b/skills/positioning-statement/SKILL.md
@@ -19,8 +19,6 @@ estimated_time: "10-15 min"
 ## Purpose
 Create a Geoffrey Moore-style positioning statement that clearly articulates who your product serves, what need it addresses, how it's categorized, what benefit it delivers, and how it differs from alternatives. Use this when you need to align stakeholders on product strategy, guide messaging, or test if your value proposition is crisp and defensible.
 
-This is not a tagline or elevator pitch—it's a strategic clarity tool that forces you to make hard choices about target, need, and differentiation.
-
 ## Key Concepts
 
 ### The Geoffrey Moore Framework
@@ -38,28 +36,11 @@ From *Crossing the Chasm*, Moore's framework splits positioning into two parts:
 - [product name]
 - **provides** [unique differentiation]
 
-### Why This Structure Works
-- **Forces specificity:** You can't say "for everyone" or "unlike all competitors"
-- **Exposes assumptions:** If you can't fill in "unlike X," you may not have defensible differentiation
-- **Focuses on outcomes, not features:** "That reduces churn by 40%" beats "that has analytics"
-- **Category anchors perception:** Saying "is a CRM" vs. "is a workflow tool" changes how buyers evaluate you
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a tagline:** "Positioning" ≠ "Nike: Just Do It"
 - **Not a feature list:** Don't say "that provides AI, automation, and integrations"
 - **Not generic:** "For businesses that need efficiency" = positioning theater
 - **Not aspirational fluff:** "That revolutionizes productivity" without specifics is noise
-
-### When to Use This
-- Defining a new product or major pivot
-- Aligning exec/founder/PM/marketing on strategy
-- Testing if your differentiation is real or imagined
-- Before writing PRDs, launch plans, or sales collateral
-
-### When NOT to Use This
-- For internal tools with captive users (positioning is for markets)
-- When you're still in problem validation (position after you know the problem)
-- As a substitute for customer research (this synthesizes insights, doesn't create them)
 
 ---
 
@@ -158,48 +139,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: "For Everyone"
-**Symptom:** "For businesses that want to grow" or "For anyone who uses software"
-
-**Consequence:** No one feels like it's *for them*. Positioning becomes invisible.
-
-**Fix:** Pick the *first* customer segment you'll serve. You can expand later, but positioning works when it's narrow.
-
----
-
-### Pitfall 2: Feature Creep in Benefit Statement
-**Symptom:** "That provides AI, automation, analytics, and integrations"
-
-**Consequence:** Sounds like a feature list, not a benefit. Buyers tune out.
-
-**Fix:** Lead with the outcome: "That reduces churn by 30% through predictive analytics." The features are how, not why.
-
----
-
-### Pitfall 3: Imaginary Competitor
-**Symptom:** "Unlike outdated legacy systems" or "Unlike traditional approaches"
-
-**Consequence:** You're positioning against a straw man. Real buyers don't recognize this alternative.
-
-**Fix:** Name the *actual* competitor or substitute behavior. If buyers use Excel, say "Unlike Excel." If they use a competitor, name them.
-
----
-
-### Pitfall 4: Differentiation Without Proof
-**Symptom:** "Provides revolutionary AI" or "Delivers unmatched speed"
-
-**Consequence:** Claims without evidence = marketing fluff. Buyers ignore it.
-
-**Fix:** Make it falsifiable: "Provides 10x faster query performance than Snowflake on datasets under 1TB" (can be tested).
-
----
-
-### Pitfall 5: Category Confusion
-**Symptom:** "Is a next-generation platform for digital transformation"
-
-**Consequence:** Buyers don't know how to evaluate you. Category = mental shelf. No shelf = no sale.
-
-**Fix:** Pick a category buyers already understand (CRM, analytics, messaging) OR commit to category creation (requires $$$ and time).
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| "For everyone" | "For businesses that want to grow" or "For anyone who uses software" | Pick the *first* customer segment. Positioning works when it's narrow. |
+| Feature creep in benefit | "That provides AI, automation, analytics, and integrations" | Lead with the outcome: "That reduces churn by 30% through predictive analytics" |
+| Imaginary competitor | "Unlike outdated legacy systems" or "Unlike traditional approaches" | Name the *actual* competitor. If buyers use Excel, say "Unlike Excel." |
+| Differentiation without proof | "Provides revolutionary AI" or "Delivers unmatched speed" | Make it falsifiable: "10x faster query performance than Snowflake on datasets under 1TB" |
+| Category confusion | "Is a next-generation platform for digital transformation" | Pick a category buyers understand, or commit to category creation (requires $$$ and time) |
 
 ---
 

--- a/skills/positioning-workshop/SKILL.md
+++ b/skills/positioning-workshop/SKILL.md
@@ -18,8 +18,6 @@ scenarios:
 ## Purpose
 Guide product managers through discovering and articulating product positioning by asking adaptive questions about target customers, unmet needs, product category, benefits, and competitive differentiation. Use this to align stakeholders on strategic positioning before writing PRDs, launch plans, or marketing materials—ensuring you've made deliberate choices about who you serve, what need you address, and how you differ from alternatives.
 
-This is not a brainstorming session—it's a structured discovery process that outputs a Geoffrey Moore positioning statement backed by evidence and strategic choices.
-
 ## Key Concepts
 
 ### The Positioning Workshop Flow
@@ -31,28 +29,10 @@ An interactive discovery process that:
 5. Establishes competitive differentiation
 6. Outputs a complete positioning statement (uses `positioning-statement.md`)
 
-### Why This Works
-- **Structured discovery:** Prevents "positioning by committee" (too vague)
-- **Evidence-based:** Uses real marketing materials, customer feedback, competitive intel
-- **Adaptive:** Questions adjust based on B2B vs. B2C, new product vs. repositioning, etc.
-- **Actionable output:** Generates a Geoffrey Moore positioning statement ready for stakeholder review
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a tagline generator:** Positioning ≠ marketing copy
 - **Not feature-first:** Starts with customer problems, not product capabilities
 - **Not consensus-driven:** Forces hard choices (can't be "for everyone")
-
-### When to Use This
-- Defining positioning for a new product
-- Repositioning an existing product (pivot, market shift)
-- Aligning stakeholders on product strategy
-- Preparing for launch or major release
-- Before writing positioning-dependent artifacts (PRD, press release, sales deck)
-
-### When NOT to Use This
-- Before customer research (positioning requires validated insights)
-- For internal tools with captive users (no market positioning needed)
-- When positioning is already clear and validated
 
 ---
 
@@ -355,48 +335,13 @@ Acme Workflows is a no-code automation platform for small business owners that r
 
 ## Common Pitfalls
 
-### Pitfall 1: "For Everyone"
-**Symptom:** Target is "all businesses" or "anyone who wants to be productive"
-
-**Consequence:** Positioning becomes invisible—no one feels it's *for them*.
-
-**Fix:** Narrow ruthlessly. Pick the *first* customer segment. You can expand later.
-
----
-
-### Pitfall 2: Need is a Feature Request
-**Symptom:** "Need better dashboards" or "Need AI-powered analytics"
-
-**Consequence:** You've jumped to solution, not problem.
-
-**Fix:** Ask "Why do they need that?" Keep asking until you hit the root need.
-
----
-
-### Pitfall 3: Category Confusion
-**Symptom:** "We're a next-generation platform for digital transformation"
-
-**Consequence:** Buyers don't know how to evaluate you.
-
-**Fix:** Pick a category buyers understand. If creating a new one, budget for category education.
-
----
-
-### Pitfall 4: Differentiation is a Feature
-**Symptom:** "Unlike competitors, we have AI"
-
-**Consequence:** Features are copiable. Not durable differentiation.
-
-**Fix:** Focus on outcomes: "Unlike competitors, we reduce setup time from 2 hours to 10 minutes."
-
----
-
-### Pitfall 5: No Customer Validation
-**Symptom:** Positioning created in a vacuum, never tested with customers
-
-**Consequence:** It sounds good internally but doesn't resonate externally.
-
-**Fix:** Read positioning statement to 5 target customers. If they don't say "Yes, that's me," revise.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| "For everyone" | Target is "all businesses" or "anyone who wants to be productive" | Narrow ruthlessly. Pick the *first* customer segment. Expand later. |
+| Need is a feature request | "Need better dashboards" or "Need AI-powered analytics" | Ask "Why do they need that?" Keep asking until you hit the root need. |
+| Category confusion | "We're a next-generation platform for digital transformation" | Pick a category buyers understand. If creating a new one, budget for category education. |
+| Differentiation is a feature | "Unlike competitors, we have AI" | Focus on outcomes: "Unlike competitors, we reduce setup time from 2 hours to 10 minutes." |
+| No customer validation | Positioning created in a vacuum, never tested with customers | Read positioning statement to 5 target customers. If they don't say "Yes, that's me," revise. |
 
 ---
 

--- a/skills/prd-development/SKILL.md
+++ b/skills/prd-development/SKILL.md
@@ -19,8 +19,6 @@ estimated_time: "60-120 min"
 ## Purpose
 Guide product managers through structured PRD (Product Requirements Document) creation by orchestrating problem framing, user research synthesis, solution definition, and success criteria into a cohesive document. Use this to move from scattered notes and Slack threads to a clear, comprehensive PRD that aligns stakeholders, provides engineering context, and serves as a source of truth—avoiding ambiguity, scope creep, and the "build what's in my head" trap.
 
-This is not a waterfall spec—it's a living document that captures strategic context, customer problems, proposed solutions, and success criteria, evolving as you learn through delivery.
-
 ## Key Concepts
 
 ### What is a PRD?
@@ -86,30 +84,6 @@ A PRD (Product Requirements Document) is a structured document that answers:
 - Unresolved decisions
 - Areas requiring discovery
 ```
-
-### Why This Works
-- **Alignment:** Ensures everyone (PM, design, eng, stakeholders) understands the "why"
-- **Context preservation:** Captures research and strategic rationale for future reference
-- **Decision log:** Documents what's in scope, out of scope, and why
-- **Execution clarity:** Provides engineering with user stories and acceptance criteria
-
-### Anti-Patterns (What This Is NOT)
-- **Not a detailed spec:** PRDs frame the problem and solution; they don't specify UI pixel-by-pixel
-- **Not waterfall:** PRDs evolve as you learn; they're not frozen contracts
-- **Not a substitute for collaboration:** PRDs complement conversation, not replace it
-
-### When to Use This
-- Starting a major feature or product initiative
-- Aligning cross-functional teams on scope and requirements
-- Documenting decisions for future reference
-- Onboarding new team members to a project
-
-### When NOT to Use This
-- For small bug fixes or trivial features (overkill)
-- When problem and solution are already clear and aligned (just write user stories)
-- For continuous discovery experiments (use Lean UX Canvas instead)
-
----
 
 ### Facilitation Source of Truth
 
@@ -570,48 +544,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: PRD Written in Isolation
-**Symptom:** PM writes PRD alone, presents finished doc to team
-
-**Consequence:** No buy-in, team doesn't understand rationale
-
-**Fix:** Collaborate on Phase 7 (user stories) with design + eng; review draft PRD before finalizing
-
----
-
-### Pitfall 2: No Evidence in Problem Statement
-**Symptom:** "We believe users have this problem" (no data, no quotes)
-
-**Consequence:** Team questions whether problem is real
-
-**Fix:** Use discovery insights from `skills/discovery-process/SKILL.md`; include customer quotes, analytics, support tickets
-
----
-
-### Pitfall 3: Solution Too Prescriptive
-**Symptom:** PRD specifies exact UI, pixel dimensions, button colors
-
-**Consequence:** Removes design collaboration, becomes waterfall spec
-
-**Fix:** Keep Phase 5 high-level; let design own UI details
-
----
-
-### Pitfall 4: No Success Metrics
-**Symptom:** PRD defines problem + solution but no metrics
-
-**Consequence:** Can't validate if feature succeeded
-
-**Fix:** Always define primary metric in Phase 6 (what you're optimizing for)
-
----
-
-### Pitfall 5: Out of Scope Not Documented
-**Symptom:** No section on what's NOT being built
-
-**Consequence:** Scope creep, stakeholders expect features not planned
-
-**Fix:** Explicitly document out of scope in Phase 8
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **PRD written in isolation** | PM writes alone, presents finished doc | Collaborate on Phase 7 with design + eng; review draft before finalizing |
+| **No evidence in problem statement** | "We believe users have this problem" (no data) | Include customer quotes, analytics, support tickets from discovery |
+| **Solution too prescriptive** | PRD specifies exact UI, pixel dimensions | Keep Phase 5 high-level; let design own UI details |
+| **No success metrics** | Problem + solution defined but no metrics | Always define primary metric in Phase 6 |
+| **Out of scope not documented** | No section on what's NOT being built | Explicitly document out of scope in Phase 8 |
 
 ---
 
@@ -647,9 +586,3 @@ Mini example excerpt:
 ### Dean's Work
 - [If Dean has PRD templates, link here]
 
----
-
-**Skill type:** Workflow
-**Suggested filename:** `prd-development.md`
-**Suggested placement:** `/skills/workflows/`
-**Dependencies:** Orchestrates 8+ component and interactive skills across 8 phases

--- a/skills/press-release/SKILL.md
+++ b/skills/press-release/SKILL.md
@@ -10,16 +10,7 @@ type: component
 ## Purpose
 Create a visionary press release following Amazon's "Working Backwards" methodology to define and communicate a product or feature before building it. Use this to align stakeholders on the customer value proposition, clarify the problem being solved, and test if the product story resonates—treating the press release as a forcing function for clarity and customer-centricity.
 
-This is not a marketing artifact for launch day—it's a planning tool that asks "If we shipped this perfectly, how would we explain it to the world?"
-
 ## Key Concepts
-
-### The Amazon Working Backwards Framework
-Popularized by Amazon, the Working Backwards process starts with a press release and FAQ before any code is written. The press release must:
-- Be written from the customer's perspective
-- Focus on the problem solved, not the features built
-- Be short (1-1.5 pages)
-- Be compelling enough that customers would want the product
 
 ### Press Release Structure
 A standard press release follows this format:
@@ -35,28 +26,11 @@ A standard press release follows this format:
 9. **Call to action:** How to learn more
 10. **Media contact:** Press contact information
 
-### Why This Works
-- **Customer-first thinking:** Forces you to articulate value from the customer's perspective
-- **Clarity forcing function:** If you can't write a compelling press release, the product idea may be weak
-- **Alignment tool:** Stakeholders can read and react to the vision before engineering starts
-- **Decision filter:** If a feature wouldn't make it into the press release, question its priority
-
 ### Anti-Patterns (What This Is NOT)
 - **Not feature-centric:** Don't list specs—focus on customer outcomes
 - **Not internal jargon:** Write for customers, not engineers
 - **Not vague:** "Revolutionizes productivity" is fluff; "Reduces report generation time from 8 hours to 10 minutes" is real
 - **Not marketing spin:** Be honest about what the product does
-
-### When to Use This
-- Defining a new product or major feature
-- Aligning stakeholders on vision before development
-- Testing if a product idea is compelling
-- Pitching to execs or securing buy-in
-
-### When NOT to Use This
-- For trivial features (don't over-engineer small tweaks)
-- After you've already built the product (too late)
-- As actual launch-day press release (this is a planning doc, not final marketing copy)
 
 ---
 
@@ -197,48 +171,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Feature List Instead of Benefits
-**Symptom:** "Includes AI, ML, OCR, NLP, and real-time sync"
-
-**Consequence:** Customers don't care about features—they care about outcomes.
-
-**Fix:** Translate features to benefits: "AI-powered automation reduces invoice processing time by 60%."
-
----
-
-### Pitfall 2: Vague Problem Statement
-**Symptom:** "Solves inefficiency in workflows"
-
-**Consequence:** No one recognizes themselves in this problem.
-
-**Fix:** Be specific: "Small business owners spend 8 hours/month manually entering invoice data."
-
----
-
-### Pitfall 3: Jargon-Heavy Language
-**Symptom:** "Leverages cutting-edge ML models to optimize enterprise-grade workflows"
-
-**Consequence:** Customers can't understand what you're saying.
-
-**Fix:** Write like you're explaining it to a friend: "Automatically handles invoices so you don't have to."
-
----
-
-### Pitfall 4: Generic Executive Quote
-**Symptom:** "We're excited to bring innovation to market"
-
-**Consequence:** Quote adds no value. Could apply to any product.
-
-**Fix:** Make it customer-focused: "Business owners shouldn't spend weekends processing invoices—they should spend that time with family."
-
----
-
-### Pitfall 5: No Data or Validation
-**Symptom:** "Customers will love this revolutionary new solution"
-
-**Consequence:** Unsubstantiated claims = marketing fluff.
-
-**Fix:** Add data: "Beta users saved an average of 5 hours per month" or "68% of SMBs cite invoice processing as their top admin burden."
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Feature list instead of benefits | "Includes AI, ML, OCR, NLP, and real-time sync" | Translate to outcomes: "AI-powered automation reduces processing time by 60%" |
+| Vague problem statement | "Solves inefficiency in workflows" | Be specific: "Small business owners spend 8 hours/month manually entering invoice data" |
+| Jargon-heavy language | "Leverages cutting-edge ML models to optimize enterprise-grade workflows" | Write plainly: "Automatically handles invoices so you don't have to" |
+| Generic executive quote | "We're excited to bring innovation to market" | Make it customer-focused: "Business owners shouldn't spend weekends processing invoices" |
+| No data or validation | "Customers will love this revolutionary new solution" | Add data: "Beta users saved an average of 5 hours per month" |
 
 ---
 

--- a/skills/prioritization-advisor/SKILL.md
+++ b/skills/prioritization-advisor/SKILL.md
@@ -15,11 +15,6 @@ scenarios:
 ---
 
 
-## Purpose
-Guide product managers in choosing the right prioritization framework by asking adaptive questions about product stage, team context, decision-making needs, and stakeholder dynamics. Use this to avoid "framework whiplash" (switching frameworks constantly) or applying the wrong framework (e.g., using RICE for strategic bets or ICE for data-driven decisions). Outputs a recommended framework with implementation guidance tailored to your context.
-
-This is not a scoring calculator—it's a decision guide that matches prioritization frameworks to your specific situation.
-
 ## Key Concepts
 
 ### The Prioritization Framework Landscape
@@ -41,29 +36,6 @@ Common frameworks and when to use them:
 - **Cost of Delay** — Urgency-based (time-sensitive features)
 - **Impact Mapping** — Goal-driven (tie features to outcomes)
 - **Story Mapping** — User journey-based (narrative flow)
-
-### Why This Works
-- **Context-aware:** Matches framework to product stage, team maturity, data availability
-- **Anti-dogmatic:** No single "best" framework—it depends on your situation
-- **Actionable:** Provides implementation steps, not just framework names
-
-### Anti-Patterns (What This Is NOT)
-- **Not a universal ranking:** Frameworks aren't "better" or "worse"—they fit different contexts
-- **Not a replacement for strategy:** Frameworks execute strategy; they don't create it
-- **Not set-it-and-forget-it:** Reassess frameworks as your product matures
-
-### When to Use This
-- Choosing a prioritization framework for the first time
-- Switching frameworks (current one isn't working)
-- Aligning stakeholders on prioritization process
-- Onboarding new PMs to team practices
-
-### When NOT to Use This
-- When you already have a working framework (don't fix what isn't broken)
-- For one-off decisions (frameworks are for recurring prioritization)
-- As a substitute for strategic vision (frameworks can't tell you what to build)
-
----
 
 ### Facilitation Source of Truth
 
@@ -379,48 +351,13 @@ After collecting responses, the agent recommends a framework:
 
 ## Common Pitfalls
 
-### Pitfall 1: Using the Wrong Framework for Your Stage
-**Symptom:** Pre-PMF startup using weighted scoring with 10 criteria
-
-**Consequence:** Overhead kills speed. You need experiments, not rigorous scoring.
-
-**Fix:** Match framework to stage. Pre-PMF = ICE or Value/Effort. Scaling = RICE. Mature = Opportunity Scoring or Kano.
-
----
-
-### Pitfall 2: Framework Whiplash
-**Symptom:** Switching frameworks every quarter
-
-**Consequence:** Team confusion, lost time, no consistency.
-
-**Fix:** Stick with one framework for 6-12 months. Reassess only when stage/context changes.
-
----
-
-### Pitfall 3: Treating Scores as Gospel
-**Symptom:** "Feature A scored 8,000, Feature B scored 7,999, so A wins"
-
-**Consequence:** Ignores strategic context, judgment, and vision.
-
-**Fix:** Use frameworks as input, not automation. PM judgment overrides scores when needed.
-
----
-
-### Pitfall 4: Solo PM Scoring
-**Symptom:** PM scores features alone, presents to team
-
-**Consequence:** Lack of buy-in, engineering/design don't trust scores.
-
-**Fix:** Collaborative scoring sessions. PM, design, engineering score together.
-
----
-
-### Pitfall 5: No Framework at All
-**Symptom:** "We prioritize by who shouts loudest"
-
-**Consequence:** HiPPO (Highest Paid Person's Opinion) wins, not data or strategy.
-
-**Fix:** Pick *any* framework. Even imperfect structure beats chaos.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Wrong framework for stage | Pre-PMF startup using weighted scoring with 10 criteria | Match framework to stage: Pre-PMF = ICE/Value-Effort, Scaling = RICE, Mature = Opportunity Scoring/Kano |
+| Framework whiplash | Switching frameworks every quarter | Stick with one for 6-12 months; reassess only when stage/context changes |
+| Treating scores as gospel | "Feature A scored 8,000 vs 7,999, so A wins" | Use frameworks as input, not automation — PM judgment overrides when needed |
+| Solo PM scoring | PM scores alone, presents to team | Collaborative scoring sessions with PM, design, and engineering |
+| No framework at all | "We prioritize by who shouts loudest" | Pick *any* framework — even imperfect structure beats chaos |
 
 ---
 
@@ -440,9 +377,3 @@ After collecting responses, the agent recommends a framework:
 ### Dean's Work
 - [If Dean has prioritization resources, link here]
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `prioritization-advisor.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** None (standalone, but informs roadmap and backlog decisions)

--- a/skills/problem-framing-canvas/SKILL.md
+++ b/skills/problem-framing-canvas/SKILL.md
@@ -18,17 +18,7 @@ scenarios:
 ## Purpose
 Guide product managers through the MITRE Problem Framing Canvas process by asking structured questions across three phases: Look Inward (examine your own assumptions and biases), Look Outward (understand who experiences the problem and who doesn't), and Reframe (synthesize insights into an actionable problem statement and "How Might We" question). Use this to ensure you're solving the right problem before jumping to solutions—avoiding confirmation bias, overlooked stakeholders, and solution-first thinking.
 
-This is not a solution brainstorm—it's a problem framing tool that broadens perspective, challenges assumptions, and produces a clear, equity-driven problem statement.
-
 ## Key Concepts
-
-### What is the MITRE Problem Framing Canvas?
-
-The Problem Framing Canvas (MITRE Innovation Toolkit, v3) is a structured framework that helps teams explore a problem space comprehensively before proposing solutions. It's partitioned into **three areas**:
-
-1. **Look Inward** — Examine your own assumptions, biases, and how you might be part of the problem
-2. **Look Outward** — Understand who experiences the problem, who benefits from it, and who's been left out
-3. **Reframe** — Synthesize insights into a clear, actionable problem statement and "How Might We" question
 
 ### Canvas Structure
 
@@ -54,28 +44,6 @@ The Problem Framing Canvas (MITRE Innovation Toolkit, v3) is a structured framew
 │ - How might we [action] as we aim to [objective]?             │
 └─────────────────────────────────────────────────────────────────┘
 ```
-
-### Why This Works
-- **Broadens perspective:** Forces you to look beyond your own assumptions
-- **Equity-driven:** Centers marginalized voices and asks "who's been left out?"
-- **Challenges biases:** Requires explicit examination of assumptions before framing problem
-- **Actionable output:** Produces HMW statement ready for solution exploration
-
-### Anti-Patterns (What This Is NOT)
-- **Not a solution brainstorm:** Canvas frames the problem; solutions come later
-- **Not a feature request list:** Focuses on underlying problems, not surface symptoms
-- **Not a one-person exercise:** Requires diverse perspectives to challenge groupthink
-
-### When to Use This
-- Starting discovery for a new initiative
-- Reframing an existing problem (suspect you're solving the wrong thing)
-- Challenging assumptions before building solutions
-- Aligning cross-functional teams on problem definition
-
-### When NOT to Use This
-- When the problem is already well-understood and validated
-- For tactical bug fixes or technical debt (no deep framing needed)
-- When stakeholders have already committed to a solution (address alignment first)
 
 ---
 
@@ -399,48 +367,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Skipping "Look Inward" (Assuming You're Neutral)
-**Symptom:** Team jumps straight to "Look Outward" without examining biases
-
-**Consequence:** Groupthink persists, assumptions unchallenged
-
-**Fix:** Force explicit discussion of assumptions and biases (Q2-Q3)
-
----
-
-### Pitfall 2: Ignoring "Who Benefits" Question
-**Symptom:** Canvas completed without exploring who benefits from problem existing
-
-**Consequence:** Miss political dynamics, resistance to change
-
-**Fix:** Always ask "Who loses if this problem is solved?" (Q6)
-
----
-
-### Pitfall 3: Generic Problem Statement
-**Symptom:** Reframed problem is vague ("Improve user experience")
-
-**Consequence:** HMW statement isn't actionable
-
-**Fix:** Make problem specific (who, what, when, consequence, root cause)
-
----
-
-### Pitfall 4: HMW Statement Is Too Narrow
-**Symptom:** "How might we add a mobile app?"
-
-**Consequence:** Constrains solution space to one idea
-
-**Fix:** Keep HMW broad: "How might we enable mobile-first users to access core workflows on any device?"
-
----
-
-### Pitfall 5: Solo Exercise (No Diverse Perspectives)
-**Symptom:** PM fills out canvas alone
-
-**Consequence:** Biases persist, marginalized voices still left out
-
-**Fix:** Facilitate canvas workshop with cross-functional team + customer input
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Skipping "Look Inward" | Team jumps to "Look Outward" without examining biases | Force explicit discussion of assumptions and biases (Q2-Q3) |
+| Ignoring "Who Benefits" | Canvas completed without exploring who benefits from problem existing | Always ask "Who loses if this problem is solved?" (Q6) |
+| Generic Problem Statement | Reframed problem is vague ("Improve user experience") | Make problem specific (who, what, when, consequence, root cause) |
+| HMW Too Narrow | "How might we add a mobile app?" constrains solution space | Keep HMW broad: "How might we enable mobile-first users to access core workflows on any device?" |
+| Solo Exercise | PM fills out canvas alone; biases persist | Facilitate canvas workshop with cross-functional team + customer input |
 
 ---
 
@@ -458,9 +391,3 @@ Mini example excerpt:
 ### Dean's Work
 - [If Dean has problem framing resources, link here]
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `problem-framing-canvas.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** Uses `skills/problem-statement/SKILL.md`

--- a/skills/problem-statement/SKILL.md
+++ b/skills/problem-statement/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Articulate a problem from the user's perspective using an empathy-driven framework that captures who they are, what they're trying to do, what's blocking them, why, and how it makes them feel. Use this to align stakeholders on the problem before jumping to solutions, and to frame product work around user outcomes rather than feature requests.
 
-This is not a requirements doc—it's a human-centered problem narrative that ensures you're solving a problem worth solving.
-
 ## Key Concepts
 
 ### The Problem Framing Framework
@@ -30,30 +28,11 @@ Based on Jobs-to-be-Done and empathy mapping, the framework structures problems 
 **Final Problem Statement:**
 - [Single, concise, empathetic summary]
 
-### Why This Structure Works
-- **Persona-centric:** Forces you to see the problem through the user's eyes
-- **Outcome-focused:** "Trying to" emphasizes desired results, not tasks
-- **Root cause analysis:** "Because" pushes past symptoms to underlying issues
-- **Emotional validation:** "Makes me feel" humanizes the problem and builds empathy
-- **Contextual:** Constraints acknowledge real-world limitations
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a solution in disguise:** "The problem is we lack AI-powered analytics" = sneaking in a solution
 - **Not a business problem:** "Our revenue is down" isn't a user problem (it's a symptom)
 - **Not a feature request:** "Users need a dashboard" isn't a problem (what are they trying to do?)
 - **Not generic:** "Users want better UX" is too vague to be actionable
-
-### When to Use This
-- Kicking off discovery or problem validation work
-- Aligning stakeholders before solutioning
-- Socializing a problem with engineering, design, or exec teams
-- When you have feature requests but unclear underlying problems
-- Pitching why a problem is worth solving
-
-### When NOT to Use This
-- When you haven't done any user research yet (don't guess—interview first)
-- For internal operational problems (this is for user-facing problems)
-- As a substitute for a PRD (this frames the problem; PRD defines the solution)
 
 ---
 
@@ -174,48 +153,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Solution Smuggling
-**Symptom:** "The problem is we don't have [specific feature]"
-
-**Consequence:** You've predetermined the solution without validating the problem.
-
-**Fix:** Reframe around the user's desired outcome, not the feature. Ask "What are they trying to achieve?"
-
----
-
-### Pitfall 2: Business Problem Disguised as User Problem
-**Symptom:** "Users want to increase our revenue" or "The problem is our churn rate"
-
-**Consequence:** These are company problems, not user problems. Users don't care about your metrics.
-
-**Fix:** Dig into *why* users churn or *what* would make them spend more. Frame it from their perspective.
-
----
-
-### Pitfall 3: Generic Personas
-**Symptom:** "I am a busy professional trying to be more productive"
-
-**Consequence:** Too broad to be actionable. Every product claims to help "busy professionals."
-
-**Fix:** Get specific. "I am a sales rep managing 50+ leads manually in spreadsheets, trying to prioritize follow-ups without missing high-value opportunities."
-
----
-
-### Pitfall 4: Symptom Instead of Root Cause
-**Symptom:** "Because the UI is confusing"
-
-**Consequence:** You're describing a symptom, not the underlying issue.
-
-**Fix:** Ask "Why is the UI confusing?" Keep asking "why" until you hit the root cause (e.g., "Because users have no mental model for how the system works").
-
----
-
-### Pitfall 5: Fabricated Emotions
-**Symptom:** "Which makes me feel empowered and delighted"
-
-**Consequence:** These sound like marketing copy, not real user emotions.
-
-**Fix:** Use actual quotes from user interviews. Real emotions: "frustrated," "overwhelmed," "anxious," "stuck."
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Solution smuggling | "The problem is we don't have [specific feature]" | Reframe around the user's desired outcome. Ask "What are they trying to achieve?" |
+| Business problem disguised as user problem | "Users want to increase our revenue" or "The problem is our churn rate" | Dig into *why* users churn. Frame from their perspective, not your metrics. |
+| Generic personas | "I am a busy professional trying to be more productive" | Get specific: "I am a sales rep managing 50+ leads in spreadsheets" |
+| Symptom instead of root cause | "Because the UI is confusing" | Keep asking "why" until you hit root cause (e.g., "users have no mental model for how the system works") |
+| Fabricated emotions | "Which makes me feel empowered and delighted" | Use actual quotes from user interviews. Real emotions: "frustrated," "overwhelmed," "stuck" |
 
 ---
 

--- a/skills/product-strategy-session/SKILL.md
+++ b/skills/product-strategy-session/SKILL.md
@@ -7,45 +7,7 @@ type: workflow
 ---
 
 
-## Purpose
-Guide product managers through a comprehensive product strategy session by orchestrating positioning, problem framing, customer discovery, and roadmap planning skills into a cohesive end-to-end process. Use this to move from vague strategic direction to concrete, validated product strategy with clear positioning, target customers, problem statements, and prioritized roadmap—ensuring alignment across stakeholders before committing to execution.
-
-This is not a one-time workshop—it's a repeatable process for establishing or refreshing product strategy, typically spanning 2-4 weeks with multiple touchpoints.
-
 ## Key Concepts
-
-### What is a Product Strategy Session?
-
-A product strategy session is a structured, multi-phase process that takes a product from strategic ambiguity to validated direction. It orchestrates:
-
-1. **Positioning & Market Context** — Define who you serve, what problem you solve, and how you're differentiated
-2. **Problem Discovery & Validation** — Frame and validate customer problems through research
-3. **Solution Exploration** — Generate opportunity solutions and prioritize based on impact
-4. **Roadmap Planning** — Sequence epics and releases based on strategy
-
-### Why This Works
-- **Structured discovery:** Prevents jumping to solutions before understanding problems
-- **Stakeholder alignment:** Creates shared mental model across exec, product, design, engineering
-- **Validated strategy:** Tests assumptions before committing resources
-- **Executable roadmap:** Connects high-level strategy to concrete work
-
-### Anti-Patterns (What This Is NOT)
-- **Not a feature brainstorm:** Strategy sessions frame problems, not just list features
-- **Not waterfall planning:** Builds in feedback loops and iteration
-- **Not a solo PM exercise:** Requires cross-functional participation
-
-### When to Use This
-- Launching a new product or major initiative
-- Annual/quarterly strategic planning cycles
-- Repositioning an existing product
-- Onboarding new product leaders (align on strategy)
-
-### When NOT to Use This
-- When strategy is already clear and validated
-- For tactical feature additions (no strategic shift needed)
-- When you lack executive sponsorship (strategy won't stick)
-
----
 
 ### Facilitation Source of Truth
 
@@ -332,48 +294,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Skipping Problem Validation
-**Symptom:** Jump from positioning to solution exploration without validating problem
-
-**Consequence:** Build solutions to unvalidated problems
-
-**Fix:** Force decision point after Phase 2: "Is problem validated?" If NO, run discovery interviews.
-
----
-
-### Pitfall 2: Solo PM Exercise
-**Symptom:** PM runs strategy session alone, presents finished strategy to team
-
-**Consequence:** No buy-in, team doesn't understand rationale
-
-**Fix:** Include cross-functional participants in workshops (design, eng, sales, CS)
-
----
-
-### Pitfall 3: Strategy Session Without Executive Sponsorship
-**Symptom:** Run full strategy session, execs don't show up for Phase 5 alignment
-
-**Consequence:** Strategy doesn't get resourced or prioritized
-
-**Fix:** Secure exec commitment upfront; schedule Phase 5 presentation before starting.
-
----
-
-### Pitfall 4: No Decision Points (Run All Phases Regardless)
-**Symptom:** Blindly follow all 6 phases without checking if discovery/experiments are needed
-
-**Consequence:** Waste time on low-uncertainty activities
-
-**Fix:** Use decision points after Phase 2 and Phase 3 to adapt workflow.
-
----
-
-### Pitfall 5: Strategy Session Becomes Permanent Process
-**Symptom:** Team spends 6 weeks in strategy mode, never executes
-
-**Consequence:** Analysis paralysis, no delivery
-
-**Fix:** Time-box strategy session to 2-4 weeks; after Phase 6, move to execution.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Skipping problem validation | Jump from positioning to solutions without validating | Force decision point after Phase 2 — run discovery interviews if needed |
+| Solo PM exercise | PM runs session alone, presents finished strategy | Include cross-functional participants in workshops (design, eng, sales, CS) |
+| No executive sponsorship | Execs don't show up for Phase 5 alignment | Secure exec commitment upfront; schedule Phase 5 presentation before starting |
+| No decision points | Blindly follow all 6 phases regardless of uncertainty | Use decision points after Phase 2 and Phase 3 to adapt workflow |
+| Permanent strategy mode | Team spends 6 weeks in strategy, never executes | Time-box to 2-4 weeks; after Phase 6, move to execution |
 
 ---
 
@@ -418,9 +345,3 @@ Mini example excerpt:
 - Productside Blueprint — Strategic product discovery
 - [If Dean has strategy session resources, link here]
 
----
-
-**Skill type:** Workflow
-**Suggested filename:** `product-strategy-session.md`
-**Suggested placement:** `/skills/workflows/`
-**Dependencies:** Orchestrates 15+ component and interactive skills across 6 phases

--- a/skills/proto-persona/SKILL.md
+++ b/skills/proto-persona/SKILL.md
@@ -7,19 +7,7 @@ type: component
 ---
 
 
-## Purpose
-Create an initial, assumption-based persona profile that synthesizes available user research, market data, and stakeholder knowledge into a working hypothesis about your target user. Use this to align teams early in product development, guide initial design decisions, and identify gaps in understanding that require validation through research.
-
-This is not a validated persona—it's a "proto" (prototype) persona that evolves as you learn more. Think of it as a structured placeholder that prevents design-by-committee while acknowledging you don't have all the answers yet.
-
 ## Key Concepts
-
-### What is a Proto-Persona?
-A proto-persona is a lightweight, hypothesis-driven persona created from:
-- **Existing research:** User interviews, surveys, analytics (if available)
-- **Market data:** Industry reports, competitor analysis, demographic trends
-- **Stakeholder knowledge:** Sales, support, and team insights
-- **Informed assumptions:** Best guesses that need validation
 
 ### Proto vs. Validated Persona
 | Proto-Persona | Validated Persona |
@@ -29,31 +17,6 @@ A proto-persona is a lightweight, hypothesis-driven persona created from:
 | Used to align teams early | Used to guide detailed design |
 | Evolves rapidly | Stable over time |
 | Good enough to start | High confidence |
-
-### Why Use Proto-Personas?
-- **Speed:** Align teams quickly without waiting for months of research
-- **Focus:** Provides a shared reference point for "who we're building for"
-- **Hypothesis framing:** Makes assumptions explicit, which can then be validated
-- **Prevents generic design:** "Design for everyone" = design for no one
-
-### Anti-Patterns (What This Is NOT)
-- **Not validated research:** Don't treat it as fact—it's a hypothesis
-- **Not a replacement for user research:** Use it to *guide* research, not avoid it
-- **Not demographic data alone:** Age and location don't explain behavior
-- **Not permanent:** Proto-personas should evolve as you learn
-
-### When to Use This
-- Early-stage product development (before extensive user research)
-- Kicking off a new feature or pivot
-- Aligning stakeholders on target users
-- Identifying research gaps (who do we need to interview?)
-
-### When NOT to Use This
-- After you've done extensive user research (create a validated persona instead)
-- For mature products with known user segments (you should already have validated personas)
-- As a substitute for quantitative data (proto-personas inform research; research validates them)
-
----
 
 ## Application
 
@@ -253,48 +216,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Demographics Without Behavior
-**Symptom:** "28 years old, lives in NYC, has a dog"
-
-**Consequence:** Demographics don't explain *why* someone would use your product.
-
-**Fix:** Add behavioral context: "Works remotely, active in 5 Slack communities, values async communication tools."
-
----
-
-### Pitfall 2: Treating Proto-Persona as Fact
-**Symptom:** "Manager Mike would never use feature X because he hates complexity"
-
-**Consequence:** You're treating an assumption as validated research.
-
-**Fix:** Add "[ASSUMPTION—VALIDATE]" tags and plan interviews to test hypotheses.
-
----
-
-### Pitfall 3: Creating 10 Proto-Personas
-**Symptom:** Trying to model every possible user type upfront
-
-**Consequence:** Analysis paralysis. Teams can't focus on a primary user.
-
-**Fix:** Start with 1-2 proto-personas (primary + secondary). Add more as you validate and expand.
-
----
-
-### Pitfall 4: Fabricating Quotes
-**Symptom:** Quotes that sound like marketing copy: "I love products that delight me!"
-
-**Consequence:** Fake personas lead to fake empathy.
-
-**Fix:** Use real quotes from interviews, support tickets, or sales calls. If you don't have quotes yet, note "[PLACEHOLDER—NEEDS RESEARCH]."
-
----
-
-### Pitfall 5: Never Validating
-**Symptom:** Proto-persona created 6 months ago, never updated
-
-**Consequence:** You're designing for a hypothesis that may be wrong.
-
-**Fix:** Plan research sprints to validate key assumptions. Evolve the proto-persona as you learn. Graduate it to a validated persona when confidence is high.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Demographics without behavior | "28 years old, lives in NYC, has a dog" | Add behavioral context: "Works remotely, active in 5 Slack communities, values async tools" |
+| Treating proto-persona as fact | "Manager Mike would never use feature X" | Add "[ASSUMPTION—VALIDATE]" tags and plan interviews to test hypotheses |
+| Creating 10 proto-personas | Trying to model every user type upfront | Start with 1-2 (primary + secondary); add more as you validate |
+| Fabricating quotes | Quotes that sound like marketing copy | Use real quotes from interviews/support tickets; note "[PLACEHOLDER—NEEDS RESEARCH]" if missing |
+| Never validating | Proto-persona created 6 months ago, never updated | Plan research sprints to validate; graduate to validated persona when confidence is high |
 
 ---
 
@@ -317,10 +245,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/proto-persona-profile.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `proto-persona.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/jobs-to-be-done/SKILL.md`, `skills/problem-statement/SKILL.md`
-**Used by:** `skills/positioning-statement/SKILL.md`, `skills/user-story/SKILL.md`, `skills/problem-statement/SKILL.md`

--- a/skills/recommendation-canvas/SKILL.md
+++ b/skills/recommendation-canvas/SKILL.md
@@ -7,11 +7,6 @@ type: component
 ---
 
 
-## Purpose
-Evaluate and propose AI product solutions using a structured canvas that assesses business outcomes, customer outcomes, problem framing, solution hypotheses, positioning, risks, and value justification. Use this to build a comprehensive, defensible recommendation for stakeholders and decision-makers—especially when proposing AI-powered features or products that carry higher uncertainty and risk.
-
-This is not a feature spec—it's a strategic proposal that articulates *why* this AI solution is worth building, *what* assumptions need validating, and *how* you'll measure success.
-
 ## Key Concepts
 
 ### The Recommendation Canvas Framework
@@ -28,32 +23,6 @@ Created for Dean Peters' Productside "AI Innovation for Product Managers" class,
 8. **Value Justification:** Why this is worth doing
 9. **Success Metrics:** SMART metrics to measure impact
 10. **What's Next:** Strategic next steps
-
-### Why This Works
-- **Outcome-driven:** Forces clarity on business AND customer value
-- **Hypothesis-centric:** Treats solution as a bet to validate, not a commitment
-- **Risk-explicit:** Makes assumptions and risks visible upfront
-- **Executive-friendly:** Comprehensive but structured for C-level review
-- **AI-appropriate:** Especially useful for AI features with high uncertainty
-
-### Anti-Patterns (What This Is NOT)
-- **Not a PRD:** This is strategic framing, not detailed requirements
-- **Not a business case (yet):** It informs the business case but needs validation first
-- **Not a feature list:** Focus on outcomes, not capabilities
-
-### When to Use This
-- Proposing a new AI-powered product or feature
-- Pitching to execs or securing budget/sponsorship
-- Evaluating whether an AI solution is worth pursuing
-- Aligning cross-functional stakeholders (product, engineering, data science, business)
-- After completing initial discovery (you need context to fill this out)
-
-### When NOT to Use This
-- For trivial features (don't over-engineer small tweaks)
-- Before any discovery work (you need user research and problem validation first)
-- As a replacement for experimentation (canvas informs experiments, not vice versa)
-
----
 
 ## Application
 
@@ -302,48 +271,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Vague Outcomes
-**Symptom:** "Business outcome: increase revenue. Product outcome: improve UX."
-
-**Consequence:** No measurability or accountability.
-
-**Fix:** Use the outcome formula: [Direction] [Metric] [Outcome] [Context] [Acceptance Criteria]. Be specific.
-
----
-
-### Pitfall 2: Solution-First Thinking
-**Symptom:** Problem statement is "We need AI-powered X"
-
-**Consequence:** You've jumped to solution without validating the problem.
-
-**Fix:** Frame problem from user perspective. Let the solution hypothesis emerge from validated pain points.
-
----
-
-### Pitfall 3: Skipping Tiny Acts of Discovery
-**Symptom:** Hypothesis → straight to roadmap, no experiments
-
-**Consequence:** High risk of building the wrong thing.
-
-**Fix:** Define 2-3 lightweight experiments. Test before committing engineering resources.
-
----
-
-### Pitfall 4: Generic PESTEL Risks
-**Symptom:** "Political: regulations might change"
-
-**Consequence:** Risk analysis is theater, not actionable.
-
-**Fix:** Be specific: "GDPR compliance for storing client email timing data requires legal review."
-
----
-
-### Pitfall 5: Weak Value Justification
-**Symptom:** "This is valuable because customers will like it"
-
-**Consequence:** Not convincing to execs.
-
-**Fix:** Use data: "Addresses #1 pain point per user research. 20% churn reduction = $500k ARR. Low tech risk."
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Vague outcomes | "Business outcome: increase revenue" | Use the outcome formula: [Direction] [Metric] [Outcome] [Context] [Acceptance Criteria] |
+| Solution-first thinking | Problem statement is "We need AI-powered X" | Frame problem from user perspective; let hypothesis emerge from validated pain points |
+| Skipping tiny acts of discovery | Hypothesis goes straight to roadmap, no experiments | Define 2-3 lightweight experiments; test before committing engineering resources |
+| Generic PESTEL risks | "Political: regulations might change" | Be specific: "GDPR compliance for storing client email timing data requires legal review" |
+| Weak value justification | "This is valuable because customers will like it" | Use data: "Addresses #1 pain point per user research. 20% churn reduction = $500k ARR" |
 
 ---
 
@@ -367,9 +301,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/recommendation-canvas-template.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `recommendation-canvas.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/problem-statement/SKILL.md`, `skills/epic-hypothesis/SKILL.md`, `skills/positioning-statement/SKILL.md`, `skills/proto-persona/SKILL.md`, `skills/jobs-to-be-done/SKILL.md`

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -19,62 +19,14 @@ estimated_time: "45-90 min"
 ## Purpose
 Guide product managers through strategic roadmap planning by orchestrating prioritization, epic definition, stakeholder alignment, and release sequencing skills into a structured process. Use this to move from disconnected feature requests to a cohesive, outcome-driven roadmap that aligns stakeholders, sequences work logically, and communicates strategic intent—avoiding "feature factory" roadmaps that lack strategic narrative or customer-centric framing.
 
-This is not a Gantt chart—it's a strategic communication tool that shows what you're building, why it matters, and how it ladders up to business outcomes.
-
 ## Key Concepts
 
-### What is Strategic Roadmap Planning?
-
-Roadmap planning is the process of:
-1. **Gathering inputs** — Customer problems, business goals, technical constraints
-2. **Defining initiatives** — Epics with clear hypotheses and success metrics
-3. **Prioritizing** — Rank initiatives by impact, effort, strategic fit
-4. **Sequencing** — Organize into releases/quarters with logical dependencies
-5. **Communicating** — Present roadmap to stakeholders with strategic narrative
-
-### Types of Roadmaps
-
-**Now/Next/Later Roadmap:**
-- **Now:** Current quarter (committed)
-- **Next:** Following quarter (high confidence)
-- **Later:** Future exploration (low confidence)
-- **Best for:** Agile teams, uncertainty, continuous discovery
-
-**Theme-Based Roadmap:**
-- Organize by strategic themes (e.g., "Retention," "Enterprise Expansion," "Mobile Experience")
-- **Best for:** Communicating to execs, showing strategic intent
-
-**Timeline Roadmap (Quarters):**
-- Q1: Epics A, B; Q2: Epics C, D; Q3: Epics E, F
-- **Best for:** Resource planning, stakeholder communication
-
-**Feature-Based Roadmap (Anti-Pattern):**
-- Lists features without context (e.g., "Dark mode," "SSO," "Advanced reporting")
-- **Why it fails:** No strategic narrative, no customer problems framed
-
-### Why This Works
-- **Outcome-driven:** Ties initiatives to business/customer outcomes
-- **Stakeholder alignment:** Transparent process reduces political friction
-- **Strategic clarity:** Shows not just "what" but "why"
-- **Flexible:** Adapts as you learn from discovery/delivery
-
-### Anti-Patterns (What This Is NOT)
-- **Not a commitment:** Roadmaps are strategic plans, not contracts
-- **Not a feature list:** Roadmaps frame problems, not just solutions
-- **Not waterfall:** Roadmaps evolve quarterly based on learning
-
-### When to Use This
-- Annual or quarterly planning cycles
-- After product strategy session (translate strategy to roadmap)
-- Onboarding new stakeholders (align on direction)
-- Reframing existing roadmap (shift from feature-driven to outcome-driven)
-
-### When NOT to Use This
-- For tactical sprint planning (use backlog instead)
-- When strategy is unclear (run product-strategy-session first)
-- When stakeholders expect date commitments (address expectations first)
-
----
+| Roadmap Type | Structure | Best For |
+|-------------|-----------|----------|
+| Now/Next/Later | Committed → High confidence → Exploration | Agile teams, continuous discovery |
+| Theme-Based | Strategic themes (Retention, Expansion, Mobile) | Exec communication, strategic intent |
+| Timeline (Quarters) | Q1: Epics A,B; Q2: Epics C,D | Resource planning, stakeholder updates |
+| Feature-Based ❌ | Feature list without context | Anti-pattern — no strategic narrative |
 
 ### Facilitation Source of Truth
 
@@ -423,48 +375,13 @@ Later: Mobile workflows (DAU lift)
 
 ## Common Pitfalls
 
-### Pitfall 1: Feature-Driven Roadmap (No Outcomes)
-**Symptom:** Roadmap lists features ("Dark mode," "SSO," "Advanced filters") with no context
-
-**Consequence:** No strategic clarity, stakeholders don't understand "why"
-
-**Fix:** Frame epics as hypotheses with success metrics (not just feature names)
-
----
-
-### Pitfall 2: Prioritizing by HiPPO (Highest Paid Person's Opinion)
-**Symptom:** Execs dictate roadmap, no data-driven prioritization
-
-**Consequence:** Build wrong things, ignore customer problems
-
-**Fix:** Use prioritization framework (RICE, ICE) to transparently score epics
-
----
-
-### Pitfall 3: Roadmap as Commitment (Waterfall Thinking)
-**Symptom:** Roadmap treated as contract, no flexibility to adjust
-
-**Consequence:** Can't pivot when you learn new information
-
-**Fix:** Communicate roadmap as "strategic plan, subject to change based on learning"
-
----
-
-### Pitfall 4: No Dependencies Mapped
-**Symptom:** Sequence epics without checking technical dependencies
-
-**Consequence:** Q2 epic blocked because Q1 dependency didn't finish
-
-**Fix:** Map dependencies explicitly in Phase 4, validate with engineering
-
----
-
-### Pitfall 5: Solo PM Roadmap (No Stakeholder Input)
-**Symptom:** PM creates roadmap alone, presents finished plan
-
-**Consequence:** No buy-in, stakeholders feel excluded
-
-**Fix:** Gather inputs (Phase 1) from all stakeholders, present draft (Phase 5) for feedback
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Feature-driven roadmap** | Lists features with no context ("Dark mode," "SSO") | Frame epics as hypotheses with success metrics |
+| **Prioritizing by HiPPO** | Execs dictate roadmap, no data-driven prioritization | Use RICE/ICE framework to transparently score epics |
+| **Roadmap as commitment** | Treated as contract, no flexibility | Communicate as "strategic plan, subject to change based on learning" |
+| **No dependencies mapped** | Epics sequenced without checking technical dependencies | Map dependencies in Phase 4, validate with engineering |
+| **Solo PM roadmap** | PM creates alone, presents finished plan | Gather inputs (Phase 1) from all stakeholders; present draft for feedback |
 
 ---
 
@@ -497,9 +414,3 @@ Later: Mobile workflows (DAU lift)
 ### Dean's Work
 - [If Dean has roadmap planning resources, link here]
 
----
-
-**Skill type:** Workflow
-**Suggested filename:** `roadmap-planning.md`
-**Suggested placement:** `/skills/workflows/`
-**Dependencies:** Orchestrates `skills/epic-hypothesis/SKILL.md`, `skills/prioritization-advisor/SKILL.md`, plus manual activities

--- a/skills/saas-economics-efficiency-metrics/SKILL.md
+++ b/skills/saas-economics-efficiency-metrics/SKILL.md
@@ -19,8 +19,6 @@ scenarios:
 
 Determine whether your SaaS business model is fundamentally viable and capital-efficient. Use this to calculate unit economics, assess profitability, manage cash runway, and decide when to scale vs. optimize. Essential for fundraising, board reporting, and making smart investment trade-offs.
 
-This is not a finance reporting tool—it's a framework for PMs to understand whether the business can sustain growth, when to prioritize efficiency over growth, and which investments have positive returns.
-
 ## Key Concepts
 
 ### Unit Economics Family
@@ -138,31 +136,6 @@ Composite metrics that measure growth vs. profitability trade-offs.
 - **Requirement:** Positive contribution required; aim for >$0 after all variable costs
 
 ---
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not vanity metrics:** High LTV means nothing if payback takes 4 years and customers churn at 3 years.
-- **Not static benchmarks:** "Good" CAC varies wildly by business model (PLG vs. enterprise sales).
-- **Not isolated numbers:** LTV:CAC ratio without payback period can mislead (great ratio, terrible cash efficiency).
-- **Not just finance's problem:** PMs must own unit economics—every feature decision impacts margins and CAC.
-
----
-
-### When to Use These Metrics
-
-**Use these when:**
-- Evaluating whether to scale acquisition (LTV:CAC, payback, magic number)
-- Deciding feature investments (margin impact, contribution to LTV)
-- Planning runway and fundraising (burn rate, runway, Rule of 40)
-- Comparing customer segments or channels (unit economics by segment)
-- Board/investor reporting (Rule of 40, magic number, LTV:CAC)
-- Choosing between growth and profitability (Rule of 40 trade-offs)
-
-**Don't use these when:**
-- Making decisions without revenue context (pair with `saas-revenue-growth-metrics`)
-- Comparing across wildly different business models without normalization
-- Early product discovery (pre-revenue focus on PMF, not unit economics)
-- Short-term tactical decisions (use engagement metrics, not LTV)
 
 ---
 
@@ -582,93 +555,18 @@ See `examples/` folder for detailed scenarios. Mini examples below:
 
 ## Common Pitfalls
 
-### Pitfall 1: Celebrating High LTV Without Checking Payback
-**Symptom:** "Our LTV:CAC is 6:1, amazing!"
-
-**Consequence:** 6:1 ratio with 48-month payback is a cash trap. You'll run out of money before recovering CAC.
-
-**Fix:** Always pair LTV:CAC with payback period. 3:1 with 10-month payback beats 6:1 with 36-month payback.
-
----
-
-### Pitfall 2: Ignoring Gross Margin When Calculating LTV
-**Symptom:** "LTV = $100/month × 36 months = $3,600"
-
-**Consequence:** You're using revenue, not profit. Actual LTV after 30% COGS = $2,520, not $3,600.
-
-**Fix:** Always include gross margin in LTV calculations. `LTV = ARPU × Margin % / Churn Rate`.
-
----
-
-### Pitfall 3: Scaling S&M with Low Magic Number
-**Symptom:** "We need to grow faster—let's double S&M spend!" (Magic Number = 0.3)
-
-**Consequence:** You're pouring gas on a broken engine. Doubling spend will just accelerate cash burn without proportional revenue growth.
-
-**Fix:** Only scale S&M when magic number >0.75. If <0.5, fix GTM efficiency first.
-
----
-
-### Pitfall 4: Using Simplistic LTV Formulas
-**Symptom:** "LTV = ARPU × Lifetime" (ignoring expansion, discount rates, cohort variance)
-
-**Consequence:** Overstating LTV for decision-making. Reality: expansion boosts LTV; discounting reduces it; cohorts vary.
-
-**Fix:** Use sophisticated LTV models for big decisions. Simple LTV ok for directional guidance only.
-
----
-
-### Pitfall 5: Forgetting Time Value of Money
-**Symptom:** "$10K revenue today = $10K revenue in 5 years"
-
-**Consequence:** Overstating LTV for long-payback businesses. $10K in 5 years is worth ~$7.8K today (at 5% discount rate).
-
-**Fix:** Discount future cash flows for LTV periods >24 months. Use NPV (net present value).
-
----
-
-### Pitfall 6: Comparing CAC Across Different Payback Periods
-**Symptom:** "Channel A has $5K CAC, Channel B has $8K CAC—Channel A is better!"
-
-**Consequence:** If Channel A has 24-month payback and Channel B has 8-month payback, Channel B is actually better (faster cash recovery).
-
-**Fix:** Compare CAC + payback together, not CAC in isolation.
-
----
-
-### Pitfall 7: Celebrating Rule of 40 >40 with Negative Cash Flow
-**Symptom:** "Rule of 40 = 50, we're crushing it!" (60% growth, -10% margin, burning $5M/month)
-
-**Consequence:** Rule of 40 doesn't account for absolute burn. You might have great balance but only 3 months runway.
-
-**Fix:** Pair Rule of 40 with burn rate and runway. Balance matters, but survival matters more.
-
----
-
-### Pitfall 8: Ignoring Segment-Specific Unit Economics
-**Symptom:** "Blended CAC is $2K, blended LTV is $10K, we're good!"
-
-**Consequence:** SMB segment might have $500 CAC / $2K LTV (great), while Enterprise has $20K CAC / $15K LTV (terrible). Blended metrics hide the problem.
-
-**Fix:** Calculate unit economics by segment. Optimize each independently.
-
----
-
-### Pitfall 9: Confusing Gross Margin with Contribution Margin
-**Symptom:** "Gross margin is 80%, our margins are great!"
-
-**Consequence:** After variable support costs (10%) and payment processing (3%), contribution margin might be 67%—not 80%.
-
-**Fix:** Track both gross margin (COGS only) AND contribution margin (all variable costs). Use contribution margin for unit economics.
-
----
-
-### Pitfall 10: Forgetting Working Capital Timing
-**Symptom:** "We have 12 months runway based on burn rate" (but all contracts are paid monthly)
-
-**Consequence:** Annual contracts paid upfront boost cash temporarily. Monthly contracts delay cash collection. Runway is longer/shorter than burn rate suggests.
-
-**Fix:** Account for working capital when calculating runway. Cash-based runway ≠ revenue-based runway.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| High LTV Without Checking Payback | "LTV:CAC 6:1, amazing!" but 48-month payback | Pair LTV:CAC with payback. 3:1 at 10mo beats 6:1 at 36mo |
+| Ignoring Margin in LTV | "LTV = $100 x 36 = $3,600" using revenue not profit | Use `ARPU x Margin % / Churn Rate` |
+| Scaling S&M with Low Magic Number | "Double S&M spend!" at Magic Number 0.3 | Only scale when >0.75. Fix GTM first if <0.5 |
+| Simplistic LTV Formulas | "LTV = ARPU x Lifetime" ignoring expansion/discounting | Use sophisticated models for big decisions |
+| Forgetting Time Value of Money | "$10K today = $10K in 5 years" | Discount future cash flows for LTV >24 months via NPV |
+| Comparing CAC Without Payback | "Channel A $5K CAC < Channel B $8K" | Compare CAC + payback together. Faster payback may win |
+| Rule of 40 With No Runway | "Rule of 40 = 50!" but 3mo runway | Pair Rule of 40 with burn rate and runway |
+| Blended Unit Economics | "Blended CAC $2K, LTV $10K" | Calculate by segment. One segment may be deeply unprofitable |
+| Gross vs. Contribution Margin | "Gross margin 80%!" | Track both. Contribution margin (all variable costs) is the real number |
+| Ignoring Working Capital Timing | "12 months runway" but all monthly billing | Cash-based runway differs from revenue-based. Account for payment timing |
 
 ---
 

--- a/skills/saas-revenue-growth-metrics/SKILL.md
+++ b/skills/saas-revenue-growth-metrics/SKILL.md
@@ -20,8 +20,6 @@ estimated_time: "10-15 min"
 
 Master revenue and retention metrics to understand SaaS business momentum, evaluate product-market fit, and make data-driven decisions about growth investments. Use this to calculate key metrics, interpret trends, identify problems early, and communicate business health to stakeholders.
 
-This is not a business intelligence tool—it's a framework for PMs to understand which metrics matter, how to calculate them correctly, and what actions to take based on the numbers.
-
 ## Key Concepts
 
 ### Revenue Metrics Family
@@ -107,31 +105,6 @@ Metrics that measure how well you keep and grow existing customers.
 - **Benchmark:** Recent cohorts should perform same or better than old cohorts
 
 ---
-
-### Anti-Patterns (What This Is NOT)
-
-- **Not profit metrics:** Revenue is top-line, not bottom-line. High revenue with negative margins is a disaster.
-- **Not vanity metrics:** Total revenue growth means nothing if driven by unsustainable discounting or margin-destroying deals.
-- **Not blended averages:** ARPU that averages $10 SMB and $1,000 enterprise customers hides segment economics.
-- **Not isolated numbers:** Churn rate alone doesn't tell the story—need to see cohort trends and NRR.
-
----
-
-### When to Use These Metrics
-
-**Use these when:**
-- Evaluating overall business health and product-market fit
-- Comparing performance across time periods or cohorts
-- Prioritizing features with direct monetization paths (ARPU impact, expansion enablers)
-- Communicating with leadership, board, or investors
-- Assessing retention problems (churn analysis, cohort degradation)
-- Measuring pricing or packaging changes (ARPU/ARPA shifts)
-
-**Don't use these when:**
-- Evaluating profitability (use margin metrics instead)
-- Assessing capital efficiency (use LTV:CAC, payback period)
-- Making product investment decisions without cost context (revenue alone isn't ROI)
-- Comparing across wildly different business models without normalization
 
 ---
 
@@ -518,93 +491,18 @@ See `examples/` folder for detailed scenarios. Mini examples below:
 
 ## Common Pitfalls
 
-### Pitfall 1: Confusing Revenue with Profit
-**Symptom:** "We grew revenue 50% this year, we're crushing it!"
-
-**Consequence:** Revenue is the top line, not bottom line. You might be growing at a loss, destroying margins, or scaling unprofitable products.
-
-**Fix:** Always pair revenue metrics with margin metrics (see `saas-economics-efficiency-metrics`). $1M revenue at 80% margin >> $2M revenue at 20% margin.
-
----
-
-### Pitfall 2: Celebrating ARPU Growth from Mix Shift
-**Symptom:** "ARPU increased 30%!" (but customer count dropped 40%)
-
-**Consequence:** ARPU rose because you lost all your small customers, not because you improved monetization.
-
-**Fix:** Analyze ARPU by cohort and segment. True ARPU improvement = same customers paying more, not losing cheap customers.
-
----
-
-### Pitfall 3: Ignoring Cohort Degradation
-**Symptom:** "Blended churn is stable at 3%"
-
-**Consequence:** Blended metrics can hide that new cohorts churn at 6% while old cohorts churn at 1%. Product-market fit is degrading.
-
-**Fix:** Always analyze retention by cohort. If newer cohorts perform worse, stop scaling and fix the product.
-
----
-
-### Pitfall 4: Logo Churn vs. Revenue Churn Confusion
-**Symptom:** "Logo churn is only 2%, we're great!"
-
-**Consequence:** You might be losing 2% of customers but 10% of revenue if you're churning large customers.
-
-**Fix:** Track both logo churn AND revenue churn. If revenue churn > logo churn, you're losing high-value customers.
-
----
-
-### Pitfall 5: Treating All Churn Equally
-**Symptom:** "We lost 50 customers this month" (no context on who)
-
-**Consequence:** Losing 50 small customers ($10/month) is different from losing 50 enterprise customers ($10K/month).
-
-**Fix:** Segment churn analysis by customer size, cohort, and reason. Weight by revenue impact, not just logo count.
-
----
-
-### Pitfall 6: Forgetting Compounding Churn
-**Symptom:** "3% monthly churn is fine, that's only 36% annually"
-
-**Consequence:** Churn compounds. 3% monthly = 31% annual churn, not 36%. Math: `1 - (1 - 0.03)^12 = 31%`.
-
-**Fix:** Use the correct formula when converting monthly to annual churn. Don't just multiply by 12.
-
----
-
-### Pitfall 7: Celebrating Gross Revenue While Net Contracts
-**Symptom:** "Gross revenue is up 20%!" (but discounts/refunds doubled)
-
-**Consequence:** Net revenue might be flat or shrinking. Discounts hide pricing power problems; refunds hide product quality issues.
-
-**Fix:** Always track gross AND net revenue. If discounts >20% or refunds >10%, investigate why.
-
----
-
-### Pitfall 8: NRR >100% from Low Churn, Not Expansion
-**Symptom:** "NRR is 105%, we're expanding!"
-
-**Consequence:** NRR can be >100% just from very low churn, without meaningful expansion. True expansion-driven NRR is >120%.
-
-**Fix:** Break down NRR into components: expansion MRR vs. churned/contracted MRR. Aim for expansion-driven NRR, not just low churn.
-
----
-
-### Pitfall 9: Revenue Concentration Risk
-**Symptom:** "We're at $10M ARR!" (but $5M is from one customer)
-
-**Consequence:** Losing that one customer cuts revenue in half. Roadmap becomes hostage to one customer's requests.
-
-**Fix:** Track revenue concentration. Ideal: Top customer <10% of revenue, Top 10 customers <40%. Diversify early.
-
----
-
-### Pitfall 10: Averaging ARPU/ARPA Across Segments
-**Symptom:** "Our ARPU is $100" (average of $10 SMB and $1,000 enterprise)
-
-**Consequence:** Blended ARPU hides segment economics. Can't make smart acquisition or product decisions.
-
-**Fix:** Calculate ARPU/ARPA by segment (SMB, mid-market, enterprise). Optimize each segment independently.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Confusing Revenue with Profit | "We grew revenue 50%!" — ignoring margins | Always pair revenue with margin metrics. $1M at 80% margin >> $2M at 20% |
+| ARPU Growth from Mix Shift | "ARPU up 30%!" but customer count dropped 40% | Analyze ARPU by cohort/segment. True improvement = same customers paying more |
+| Ignoring Cohort Degradation | "Blended churn stable at 3%" | Analyze by cohort. If newer cohorts churn faster, stop scaling and fix product |
+| Logo vs. Revenue Churn Confusion | "Logo churn only 2%!" but losing large customers | Track both. If revenue churn > logo churn, you're losing high-value customers |
+| Treating All Churn Equally | "Lost 50 customers" with no size context | Segment by customer size and reason. Weight by revenue impact |
+| Forgetting Compounding Churn | "3% monthly = 36% annual" | Use `1 - (1 - 0.03)^12 = 31%`. Don't multiply by 12 |
+| Gross Revenue While Net Contracts | "Gross up 20%!" but discounts doubled | Track gross AND net. Investigate if discounts >20% or refunds >10% |
+| NRR >100% from Low Churn Only | "NRR 105%, we're expanding!" | Break NRR into components. Aim for expansion-driven NRR, not just low churn |
+| Revenue Concentration Risk | $10M ARR but $5M from one customer | Top customer <10%, Top 10 <40%. Diversify early |
+| Averaging ARPU Across Segments | "ARPU is $100" blending $10 SMB and $1K enterprise | Calculate ARPU/ARPA by segment. Optimize each independently |
 
 ---
 

--- a/skills/skill-authoring-workflow/SKILL.md
+++ b/skills/skill-authoring-workflow/SKILL.md
@@ -14,12 +14,6 @@ scenarios:
   - "What workflow should I use to author a new skill in this repo?"
 ---
 
-## Purpose
-
-Create or update PM skills without chaos. This workflow turns rough notes, workshop content, or half-baked prompt dumps into compliant `skills/<skill-name>/SKILL.md` assets that actually pass validation and belong in this repo.
-
-Use it when you want to ship a new skill without "looks good to me" roulette.
-
 ## Key Concepts
 
 ### Dogfood First

--- a/skills/storyboard/SKILL.md
+++ b/skills/storyboard/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Create a 6-frame visual narrative that tells the story of a user's journey from problem to solution, using the classic storytelling arc to build empathy, illustrate value, and make abstract product concepts concrete. Use this to align stakeholders, pitch features, communicate vision, or test if your solution resonates emotionally before building it.
 
-This is not a UI mockup—it's a storytelling tool that brings the human side of your product to life.
-
 ## Key Concepts
 
 ### The 6-Frame Storyboard Structure
@@ -23,30 +21,6 @@ Based on classic narrative arcs, the 6-frame format follows this pattern:
 4. **Frame 4: The Solution Appears** — Introduce your product/feature
 5. **Frame 5: The "Aha" Moment** — Show the user experiencing the breakthrough
 6. **Frame 6: Life After the Solution** — Illustrate the improved state
-
-### Why This Works
-- **Emotional engagement:** Stories create empathy in ways specs can't
-- **Concrete over abstract:** Visual narrative makes vague concepts tangible
-- **Memorable:** People remember stories better than feature lists
-- **Alignment tool:** Stakeholders can react to a story and give feedback
-- **Low-fidelity:** Doesn't require polished design—sketches work great
-
-### Anti-Patterns (What This Is NOT)
-- **Not a user flow diagram:** This is emotional storytelling, not process documentation
-- **Not a feature demo:** Focus on user outcomes, not product capabilities
-- **Not marketing copy:** Authentic narrative, not hype
-
-### When to Use This
-- Pitching a new product or feature to stakeholders
-- Aligning teams on user value (product, design, engineering, execs)
-- Testing if a product idea resonates emotionally
-- Communicating vision at all-hands or investor meetings
-- Validating problem/solution fit before building
-
-### When NOT to Use This
-- For technical implementation details (use architecture diagrams instead)
-- When the user problem is trivial or well-understood
-- As a replacement for user research (storyboards illustrate insights, don't create them)
 
 ---
 
@@ -180,48 +154,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Generic Persona
-**Symptom:** "Meet User, a busy professional"
-
-**Consequence:** No one identifies with this character.
-
-**Fix:** Get specific: "Meet Sarah, 35, freelance designer, juggling 10 clients, home office, loves design but hates admin."
-
----
-
-### Pitfall 2: Weak Problem
-**Symptom:** "User has a problem with efficiency"
-
-**Consequence:** Problem doesn't resonate emotionally.
-
-**Fix:** Make it visceral: "Sarah spends 8 hours/month chasing overdue invoices, missing family dinners, feeling anxious about cash flow."
-
----
-
-### Pitfall 3: Forced Solution Introduction
-**Symptom:** "User magically discovers our product"
-
-**Consequence:** Feels contrived, not authentic.
-
-**Fix:** Show realistic discovery: "Sarah sees a recommendation in a designer forum" or "Sarah's colleague mentions it."
-
----
-
-### Pitfall 4: Feature-Centric "Aha" Moment
-**Symptom:** "User sees the dashboard and loves the features"
-
-**Consequence:** No emotional payoff.
-
-**Fix:** Focus on outcome: "Sarah gets notification: '$5,000 received!' She's relieved—no awkward call needed."
-
----
-
-### Pitfall 5: Vague "After" State
-**Symptom:** "Life is better now"
-
-**Consequence:** Not aspirational or concrete.
-
-**Fix:** Be specific: "Sarah leaves work at 6pm now, spending evenings with her kids instead of chasing clients. On-time payments jumped from 50% to 80%."
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Generic Persona | "Meet User, a busy professional" | Get specific: "Sarah, 35, freelance designer, 10 clients, hates admin" |
+| Weak Problem | "User has a problem with efficiency" | Make it visceral: "8 hours/month chasing invoices, missing family dinners" |
+| Forced Solution Introduction | "User magically discovers our product" | Show realistic discovery: forum recommendation, colleague mention |
+| Feature-Centric "Aha" Moment | "User sees dashboard, loves features" | Focus on outcome: "'$5,000 received!' — no awkward call needed" |
+| Vague "After" State | "Life is better now" | Be specific: "Leaves work at 6pm, on-time payments jumped 50% to 80%" |
 
 ---
 
@@ -244,9 +183,3 @@ Mini example excerpt:
 ### Provenance
 - Adapted from `prompts/storyboard-storytelling-prompt.md` in the `https://github.com/deanpeters/product-manager-prompts` repo.
 
----
-
-**Skill type:** Component
-**Suggested filename:** `storyboard.md`
-**Suggested placement:** `/skills/components/`
-**Dependencies:** References `skills/proto-persona/SKILL.md`, `skills/problem-statement/SKILL.md`, `skills/positioning-statement/SKILL.md`, `skills/jobs-to-be-done/SKILL.md`

--- a/skills/tam-sam-som-calculator/SKILL.md
+++ b/skills/tam-sam-som-calculator/SKILL.md
@@ -10,8 +10,6 @@ type: interactive
 ## Purpose
 Guide product managers through calculating Total Addressable Market (TAM), Serviceable Available Market (SAM), and Serviceable Obtainable Market (SOM) for a product idea by asking adaptive, contextually relevant questions. Use this to build defensible market size estimates backed by real-world citations, economic projections, and population data—essential for pitching to investors, securing budget, or validating product-market fit.
 
-This is not a back-of-napkin guess—it's a structured, citation-backed analysis that withstands scrutiny.
-
 ## Key Concepts
 
 ### TAM/SAM/SOM Framework
@@ -32,27 +30,10 @@ The three-tier market sizing model:
 - Accounts for competition, market constraints, go-to-market capacity
 - "What can we capture in the next 1-3 years?"
 
-### Why This Works
-- **Top-down validation:** TAM → SAM → SOM ensures estimates are grounded in reality
-- **Investor-friendly:** Standard framework VCs and execs understand
-- **Citation-backed:** Real data sources (Census, Statista, World Bank) add credibility
-- **Adaptive:** Questions adjust based on context (B2B vs. B2C, US vs. global, etc.)
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a single-number guess:** "The market is $10B" without supporting data
 - **Not static:** Markets evolve—reassess annually
 - **Not a substitute for customer validation:** Market size ≠ product-market fit
-
-### When to Use This
-- Pitching to investors or execs (need market size in deck)
-- Validating product ideas (is the market big enough?)
-- Prioritizing product lines (which has bigger opportunity?)
-- Setting growth targets (what's realistic to capture?)
-
-### When NOT to Use This
-- For internal tools with captive users (no external market)
-- Before defining the problem (market sizing requires clear problem space)
-- As the only validation (pair with customer research)
 
 ---
 
@@ -317,48 +298,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: TAM Without Citations
-**Symptom:** "The market is $50B" (no source)
-
-**Consequence:** Can't defend the number to investors or execs.
-
-**Fix:** Cite industry reports (Gartner, IBISWorld, Statista) with URLs.
-
----
-
-### Pitfall 2: SOM Equals SAM
-**Symptom:** "SAM is $5B, SOM is $5B" (assuming 100% capture)
-
-**Consequence:** Unrealistic projection—no market has zero competition.
-
-**Fix:** SOM should be 1-20% of SAM in Year 1-3, accounting for competition.
-
----
-
-### Pitfall 3: No Population Estimates
-**Symptom:** Only dollar amounts, no customer counts
-
-**Consequence:** Can't build sales/marketing plans without knowing customer volume.
-
-**Fix:** Always include population (e.g., "1.2M businesses" or "60K customers in Year 1").
-
----
-
-### Pitfall 4: Static Assumptions
-**Symptom:** TAM/SAM/SOM calculated once, never updated
-
-**Consequence:** Stale data as markets shift.
-
-**Fix:** Reassess annually. Markets grow/shrink, competition changes, new data emerges.
-
----
-
-### Pitfall 5: Ignoring GTM Constraints
-**Symptom:** "SOM is 50% of SAM in Year 1" (but no sales team)
-
-**Consequence:** SOM isn't realistic given GTM capacity.
-
-**Fix:** Ground SOM in GTM constraints (sales capacity, marketing budget, conversion rates).
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| TAM without citations | "The market is $50B" (no source) | Cite industry reports (Gartner, IBISWorld, Statista) with URLs |
+| SOM equals SAM | "SAM is $5B, SOM is $5B" (assuming 100% capture) | SOM should be 1-20% of SAM in Year 1-3, accounting for competition |
+| No population estimates | Only dollar amounts, no customer counts | Always include population (e.g., "1.2M businesses" or "60K customers in Year 1") |
+| Static assumptions | TAM/SAM/SOM calculated once, never updated | Reassess annually. Markets grow/shrink, competition changes, new data emerges |
+| Ignoring GTM constraints | "SOM is 50% of SAM in Year 1" (but no sales team) | Ground SOM in GTM constraints (sales capacity, marketing budget, conversion rates) |
 
 ---
 

--- a/skills/user-story-mapping-workshop/SKILL.md
+++ b/skills/user-story-mapping-workshop/SKILL.md
@@ -7,11 +7,6 @@ type: interactive
 ---
 
 
-## Purpose
-Guide product managers through creating a user story map by asking adaptive questions about the system, users, workflow, and priorities—then generating a two-dimensional map with backbone (activities), user tasks, and release slices. Use this to move from flat backlogs to visual story maps that communicate the big picture, identify missing functionality, and enable meaningful release planning—avoiding "context-free mulch" where stories lose connection to the overall system narrative.
-
-This is not a backlog generator—it's a visual communication framework that organizes work by user workflow (horizontal) and priority (vertical).
-
 ## Key Concepts
 
 ### What is a User Story Map?
@@ -40,30 +35,6 @@ Details/Acceptance Criteria (at the bottom)
 **Ribs:** Supporting tasks descend vertically under each activity, indicating priority through placement.
 
 **Left-to-Right, Top-to-Bottom Build Strategy:** Build incrementally across all major features rather than completing one feature fully before starting another.
-
-### Why This Works
-- **Visual communication:** Story maps remain displayed as information radiators, maintaining focus on the big picture
-- **Narrative structure:** Organizes by user workflow, not technical architecture
-- **Release planning:** Horizontal slices reveal MVPs and incremental releases
-- **Gap identification:** Reveals missing functionality that flat backlogs obscure
-
-### Anti-Patterns (What This Is NOT)
-- **Not a Gantt chart:** Story maps show priority, not time estimates
-- **Not technical architecture:** Maps follow user workflow, not system layers (UI → API → DB)
-- **Not a project plan:** It's a discovery and communication tool, not a schedule
-
-### When to Use This
-- Starting a new product or major feature
-- Reframing an existing backlog (moving from flat list to visual map)
-- Aligning stakeholders on scope and priorities
-- Planning MVP or incremental releases
-
-### When NOT to Use This
-- Single-feature projects (story map overkill)
-- When backlog is already well-understood and prioritized
-- For technical refactoring work (no user workflow to map)
-
----
 
 ### Facilitation Source of Truth
 
@@ -406,48 +377,13 @@ UI Layer → API Layer → Database Layer → Deployment
 
 ## Common Pitfalls
 
-### Pitfall 1: Flat Backlog in Disguise
-**Symptom:** Story map is just a vertical list, no horizontal narrative
-
-**Consequence:** Loses communication benefit; still "context-free mulch"
-
-**Fix:** Force horizontal structure—activities across top, tasks descending vertically
-
----
-
-### Pitfall 2: Technical Architecture as Backbone
-**Symptom:** Backbone = "Frontend → Backend → Database"
-
-**Consequence:** Not user-centric, can't deliver value incrementally
-
-**Fix:** Backbone should follow user workflow, not system layers
-
----
-
-### Pitfall 3: Feature-Complete Waterfall
-**Symptom:** Release 1 = "Build Activity 1 fully," Release 2 = "Build Activity 2 fully"
-
-**Consequence:** No end-to-end value until all activities complete
-
-**Fix:** Walking skeleton = thin slice across ALL activities, incrementally enhanced
-
----
-
-### Pitfall 4: Too Much Detail Too Soon
-**Symptom:** Trying to map every edge case and acceptance criterion upfront
-
-**Consequence:** Analysis paralysis, lost big picture
-
-**Fix:** Start with backbone + high-level tasks, refine later
-
----
-
-### Pitfall 5: Map Hidden in a Tool
-**Symptom:** Story map lives in Jira/Miro, never displayed
-
-**Consequence:** Loses value as information radiator
-
-**Fix:** Print/post map physically; make it visible to team daily
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Flat backlog in disguise | Story map is just a vertical list, no horizontal narrative | Force horizontal structure — activities across top, tasks descending vertically |
+| Technical architecture as backbone | Backbone = "Frontend → Backend → Database" | Backbone should follow user workflow, not system layers |
+| Feature-complete waterfall | Release 1 = "Build Activity 1 fully" | Walking skeleton = thin slice across ALL activities, incrementally enhanced |
+| Too much detail too soon | Mapping every edge case and acceptance criterion upfront | Start with backbone + high-level tasks, refine later |
+| Map hidden in a tool | Story map lives in Jira/Miro, never displayed | Print/post map physically; make it visible to team daily |
 
 ---
 
@@ -469,9 +405,3 @@ UI Layer → API Layer → Database Layer → Deployment
 ### Provenance
 - Derived from `skills/user-story/SKILL.md`, `skills/user-story-splitting/SKILL.md`, and `skills/user-story-mapping/SKILL.md`.
 
----
-
-**Skill type:** Interactive
-**Suggested filename:** `user-story-mapping-workshop.md`
-**Suggested placement:** `/skills/interactive/`
-**Dependencies:** Uses `skills/user-story-mapping/SKILL.md`, `skills/user-story/SKILL.md`, `skills/proto-persona/SKILL.md`

--- a/skills/user-story-mapping/SKILL.md
+++ b/skills/user-story-mapping/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Visualize the user journey by creating a hierarchical map that breaks down high-level activities into steps and tasks, organized left-to-right as a narrative flow. Use this to build shared understanding across product, design, and engineering, prioritize features based on user workflows, and identify gaps or opportunities in the user experience.
 
-This is not a backlog—it's a strategic artifact that shows *how* users accomplish their goals, which then informs *what* to build.
-
 ## Key Concepts
 
 ### The Jeff Patton Story Mapping Framework
@@ -43,29 +41,10 @@ Segment → Persona → Narrative (User's goal)
   ...            ...            ...            ...            ...
 ```
 
-### Why This Works
-- **User-centric:** Organizes work around user goals, not engineering modules
-- **Shared understanding:** Product, design, engineering all see the same journey
-- **Prioritization clarity:** Top tasks = MVP, lower tasks = future iterations
-- **Gap identification:** Missing steps or tasks become obvious
-- **Release planning:** Draw horizontal "release lines" to define scope
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a Gantt chart:** This isn't project management—it's user journey visualization
 - **Not a feature list:** Activities aren't features—they're user behaviors
 - **Not static:** Story maps evolve as you learn more about users
-
-### When to Use This
-- Kicking off a new product or major feature
-- Aligning stakeholders on user workflow
-- Prioritizing backlog based on user needs
-- Identifying MVP vs. future releases
-- Onboarding new team members to the product vision
-
-### When NOT to Use This
-- For trivial features (don't map what you already understand)
-- When user workflows are constantly changing (map stabilizes workflows)
-- As a replacement for user stories (the map informs stories, doesn't replace them)
 
 ---
 
@@ -214,48 +193,13 @@ See `examples/sample.md` for a full story map example.
 
 ## Common Pitfalls
 
-### Pitfall 1: Activities Are Features, Not User Behaviors
-**Symptom:** "Activity 1: Use the dashboard. Activity 2: Generate reports."
-
-**Consequence:** You've mapped the product, not the user journey.
-
-**Fix:** Reframe as user actions: "Activity 1: Monitor project progress. Activity 2: Summarize work for stakeholders."
-
----
-
-### Pitfall 2: Too Many Activities
-**Symptom:** 10+ activities across the backbone
-
-**Consequence:** Map becomes overwhelming and loses focus.
-
-**Fix:** Consolidate. If you have 10 activities, you're likely mixing activities with steps. Aim for 3-5 high-level activities.
-
----
-
-### Pitfall 3: Tasks Are Too Vague
-**Symptom:** "Task 1: Do the thing"
-
-**Consequence:** Can't prioritize or estimate vague tasks.
-
-**Fix:** Be specific: "Task 1: Enter client email address in the 'Bill To' field."
-
----
-
-### Pitfall 4: Ignoring Vertical Prioritization
-**Symptom:** All tasks at the same level—no MVP vs. future releases defined
-
-**Consequence:** No clarity on what to build first.
-
-**Fix:** Explicitly prioritize. Draw release lines. Force hard choices about what's MVP.
-
----
-
-### Pitfall 5: Mapping in Isolation
-**Symptom:** PM creates the map alone, then presents it to the team
-
-**Consequence:** No shared ownership or understanding.
-
-**Fix:** Map collaboratively. Run a story mapping workshop with product, design, and engineering.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Activities are features, not user behaviors | "Activity 1: Use the dashboard. Activity 2: Generate reports." | Reframe as user actions: "Monitor project progress," "Summarize work for stakeholders" |
+| Too many activities | 10+ activities across the backbone | Consolidate. You're likely mixing activities with steps. Aim for 3-5. |
+| Tasks are too vague | "Task 1: Do the thing" | Be specific: "Enter client email address in the 'Bill To' field" |
+| Ignoring vertical prioritization | All tasks at the same level — no MVP vs. future releases | Draw release lines. Force hard choices about what's MVP. |
+| Mapping in isolation | PM creates the map alone, then presents to team | Map collaboratively with product, design, and engineering |
 
 ---
 

--- a/skills/user-story-splitting/SKILL.md
+++ b/skills/user-story-splitting/SKILL.md
@@ -10,8 +10,6 @@ type: component
 ## Purpose
 Break down large user stories, epics, or features into smaller, independently deliverable stories using systematic splitting patterns. Use this to make work more manageable, reduce risk, enable faster feedback cycles, and maintain flow in agile development. This skill applies to user stories, epics, and any work that's too large to complete in a single sprint.
 
-This is not arbitrary slicing—it's strategic decomposition that preserves user value while reducing complexity.
-
 ## Key Concepts
 
 ### The Story Splitting Framework
@@ -26,29 +24,10 @@ Based on Richard Lawrence and Peter Green's "Humanizing Work Guide to Splitting 
 7. **DevOps steps:** Split by deployment or infrastructure requirements
 8. **Tiny Acts of Discovery (TADs):** When none of the above apply, use small experiments to unpack unknowns
 
-### Why Split Stories?
-- **Faster feedback:** Smaller stories ship sooner, allowing earlier validation
-- **Reduced risk:** Less to build = less that can go wrong
-- **Better estimation:** Small stories are easier to estimate accurately
-- **Maintain flow:** Keeps work moving through the sprint without bottlenecks
-- **Testability:** Smaller scope = easier to write and run tests
-
 ### Anti-Patterns (What This Is NOT)
 - **Not horizontal slicing:** Don't split into "front-end story" and "back-end story" (each story should deliver user value)
 - **Not task decomposition:** Stories aren't tasks ("Set up database," "Write API")
 - **Not arbitrary chopping:** Don't split "Add user management" into "Add user" and "Management" (meaningless)
-
-### When to Use This
-- Story is too large for a single sprint
-- Multiple "When" or "Then" statements in acceptance criteria
-- Epic needs to be broken down into deliverable increments
-- Team can't reach consensus on story size or scope
-- Story has multiple personas or workflows bundled together
-
-### When NOT to Use This
-- Story is already small and well-scoped (don't over-split)
-- Splitting would create dependencies that slow delivery
-- The story is a technical task (use engineering task breakdown instead)
 
 ---
 
@@ -231,48 +210,13 @@ As a team admin, I want to manage team members so that I can control access.
 
 ## Common Pitfalls
 
-### Pitfall 1: Horizontal Slicing (Technical Layers)
-**Symptom:** "Story 1: Build the API. Story 2: Build the UI."
-
-**Consequence:** Neither story delivers user value independently.
-
-**Fix:** Split vertically—each story should include front-end + back-end work to deliver a complete user-facing capability.
-
----
-
-### Pitfall 2: Over-Splitting
-**Symptom:** "Story 1: Add button. Story 2: Wire button to API. Story 3: Display result."
-
-**Consequence:** Creates unnecessary overhead and dependencies.
-
-**Fix:** Only split when the story is too large. A 2-day story doesn't need splitting.
-
----
-
-### Pitfall 3: Meaningless Splits
-**Symptom:** "Story 1: First half of feature. Story 2: Second half of feature."
-
-**Consequence:** Arbitrary splits that don't map to user value or workflow.
-
-**Fix:** Use one of the 8 splitting patterns—each split should have a clear rationale.
-
----
-
-### Pitfall 4: Creating Hard Dependencies
-**Symptom:** "Story 2 can't start until Story 1 is 100% done, tested, and deployed."
-
-**Consequence:** No parallelization, slows delivery.
-
-**Fix:** Split in a way that allows independent development. If dependencies are unavoidable, prioritize Story 1.
-
----
-
-### Pitfall 5: Ignoring the "So That"
-**Symptom:** Split stories have the same "so that" statement.
-
-**Consequence:** You've split the action but not the outcome—likely a task decomposition, not a story split.
-
-**Fix:** Ensure each split has a distinct user outcome. If not, reconsider the split pattern.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Horizontal slicing | "Story 1: Build the API. Story 2: Build the UI." | Split vertically — each story delivers a complete user-facing capability |
+| Over-splitting | "Story 1: Add button. Story 2: Wire button to API." | Only split when the story is too large. A 2-day story doesn't need splitting. |
+| Meaningless splits | "Story 1: First half. Story 2: Second half." | Use one of the 8 splitting patterns — each split needs a clear rationale |
+| Creating hard dependencies | "Story 2 can't start until Story 1 is done, tested, and deployed" | Split to allow independent development. If unavoidable, prioritize Story 1. |
+| Ignoring the "so that" | Split stories share the same "so that" statement | Ensure each split has a distinct user outcome. If not, reconsider the split pattern. |
 
 ---
 

--- a/skills/user-story/SKILL.md
+++ b/skills/user-story/SKILL.md
@@ -19,8 +19,6 @@ estimated_time: "5-10 min"
 ## Purpose
 Create clear, concise user stories that combine Mike Cohn's user story format with Gherkin-style acceptance criteria. Use this to translate user needs into actionable development work that focuses on outcomes, ensures shared understanding between product and engineering, and provides testable success criteria.
 
-This is not a feature spec—it's a conversation starter that captures *who* benefits, *what* they're trying to do, *why* it matters, and *how* you'll know it works.
-
 ## Key Concepts
 
 ### The Mike Cohn + Gherkin Format
@@ -38,29 +36,11 @@ A user story combines:
 - **When:** [Event that triggers the action]
 - **Then:** [Expected outcome]
 
-### Why This Structure Works
-- **User-centric:** Forces focus on who benefits and why
-- **Outcome-focused:** "So that" emphasizes the value delivered, not just the action
-- **Testable:** Gherkin acceptance criteria are concrete and verifiable
-- **Conversational:** Story is the opening for discussion, not the final spec
-- **Shared language:** Product, engineering, and QA all understand the format
-
 ### Anti-Patterns (What This Is NOT)
 - **Not a task:** "As a developer, I want to refactor the database" (this is a tech task, not user value)
 - **Not a feature list:** "I want dashboards, reports, and analytics" (this is too big—needs splitting)
 - **Not vague:** "I want a better experience" (unmeasurable, no clear outcome)
 - **Not a contract:** Stories are placeholders for conversation, not locked-in specs
-
-### When to Use This
-- Translating user needs into development work
-- Backlog grooming and sprint planning
-- Communicating value to engineering and design
-- Ensuring testable acceptance criteria exist before development
-
-### When NOT to Use This
-- For pure technical debt or refactoring (use engineering tasks instead)
-- When stories are too large (split first—see `skills/user-story-splitting/SKILL.md`)
-- Before understanding the user problem (write a problem statement first)
 
 ---
 
@@ -196,48 +176,13 @@ Mini example excerpt:
 
 ## Common Pitfalls
 
-### Pitfall 1: Technical Tasks Disguised as User Stories
-**Symptom:** "As a developer, I want to refactor the API, so that the code is cleaner"
-
-**Consequence:** This is an engineering task, not a user story. No user value is delivered.
-
-**Fix:** If there's no user outcome, it's not a user story—use an engineering task or tech debt ticket instead.
-
----
-
-### Pitfall 2: "As a User" (Too Generic)
-**Symptom:** Every story starts with "As a user"
-
-**Consequence:** No persona clarity. Different users have different needs.
-
-**Fix:** Use specific personas: "As a trial user," "As a paid subscriber," "As an admin," etc. (reference `skills/proto-persona/SKILL.md`)
-
----
-
-### Pitfall 3: "So That" Restates "I Want To"
-**Symptom:** "I want to click the save button, so that I can save my work"
-
-**Consequence:** No insight into *why* the user cares. Just restating the action.
-
-**Fix:** Dig into the motivation: "so that I don't lose my progress if the page crashes" (real outcome).
-
----
-
-### Pitfall 4: Multiple When/Then Statements
-**Symptom:** Acceptance criteria with 5 "When" statements and 5 "Then" statements
-
-**Consequence:** Story is too big. Likely multiple features bundled together.
-
-**Fix:** Split the story using `skills/user-story-splitting/SKILL.md`. Each When/Then pair should be its own story (or at least evaluated for splitting).
-
----
-
-### Pitfall 5: Untestable Acceptance Criteria
-**Symptom:** "Then the user has a better experience" or "Then it's faster"
-
-**Consequence:** QA can't verify success. Ambiguous definition of "done."
-
-**Fix:** Make it measurable: "Then the page loads in under 2 seconds" or "Then the user sees a success confirmation message."
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Technical tasks disguised as stories | "As a developer, I want to refactor the API" | If there's no user outcome, use an engineering task or tech debt ticket instead |
+| "As a user" (too generic) | Every story starts with "As a user" | Use specific personas: "As a trial user," "As a paid subscriber," "As an admin" |
+| "So that" restates "I want to" | "I want to click save, so that I can save my work" | Dig into motivation: "so that I don't lose progress if the page crashes" |
+| Multiple When/Then statements | Acceptance criteria with 5 "When" and 5 "Then" statements | Split using `skills/user-story-splitting/SKILL.md`. Each When/Then pair = its own story |
+| Untestable acceptance criteria | "Then the user has a better experience" | Make measurable: "Then the page loads in under 2 seconds" |
 
 ---
 

--- a/skills/vp-cpo-readiness-advisor/SKILL.md
+++ b/skills/vp-cpo-readiness-advisor/SKILL.md
@@ -20,8 +20,6 @@ estimated_time: "15-20 min"
 
 Guide Directors and senior product leaders through the specific challenges of the transition to VP or CPO using adaptive questions and targeted coaching. Diagnoses where you are in the journey and delivers practical, lived-experience coaching calibrated to your situation — not generic executive advice.
 
-The VP/CPO transition is not a continuation of the Director transition. The landscape changes. Strategy becomes largely unwritten. Your primary customer may shift. You stop using product language with executives. Constraints don't disappear — the Rubik's Cube just goes from 3×3 to 9×9. This advisor names what's actually hard at this level and what to do about it.
-
 ## Key Concepts
 
 ### The Three Ps Framework
@@ -356,39 +354,12 @@ See `examples/conversation-flow.md` for a full interaction covering the evaluati
 
 ## Common Pitfalls
 
-### Pitfall 1: Conflating VP and CPO Transitions
-**Symptom:** Treating the Director → VP and VP → CPO transitions as the same move at different scales
-
-**Consequence:** The VP → CPO shift is a qualitative change (product-first to business-first), not just a scope expansion. Applying VP thinking to CPO problems produces the wrong answers.
-
-**Fix:** Explicitly identify which transition you're navigating. The language shift alone is a signal: if you're still leading with product language in executive forums as CPO, you haven't made the transition.
-
----
-
-### Pitfall 2: Waiting for Empowerment
-**Symptom:** Taking the VP/CPO role expecting to finally have the authority to do what you've always known was right
-
-**Consequence:** The Empowerment Myth sets you up for disillusionment. Constraints persist; they just get bigger.
-
-**Fix:** Reframe before you arrive: "My job is not to be empowered. My job is to develop the capacity to navigate larger constraints than I've ever faced."
-
----
-
-### Pitfall 3: Neglecting the Alliance Layer
-**Symptom:** Focusing primarily on managing your direct reports and product organization; treating exec team relationships as secondary
-
-**Consequence:** Without executive alliances, every significant product decision can be undermined by a peer who wasn't brought along.
-
-**Fix:** Your most important team at VP/CPO level is the executive staff, not the product org. Invest in those relationships at least as deliberately as you invest in developing your team.
-
----
-
-### Pitfall 4: Misidentifying Your Situation
-**Symptom:** Selecting "preparing" when you're actually recalibrating a role that isn't working
-
-**Consequence:** You get coaching for a transition you've already made, not for the problem you're actually in.
-
-**Fix:** Be honest about the gap between where you aspire to be and where you actually are. The recalibrating branch will be more useful if the role has already landed badly.
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Conflating VP and CPO transitions | Treating Director→VP and VP→CPO as the same move at different scales | Explicitly identify which transition you're navigating; the VP→CPO shift is qualitative (product-first to business-first), not just scope expansion |
+| Waiting for empowerment | Taking the role expecting to finally have authority to do what you've always known was right | Reframe: "My job is to develop the capacity to navigate larger constraints, not to be empowered" |
+| Neglecting the alliance layer | Focusing on direct reports; treating exec team relationships as secondary | Your most important team at VP/CPO level is the executive staff, not the product org |
+| Misidentifying your situation | Selecting "preparing" when you're actually recalibrating a role that isn't working | Be honest about the gap between aspiration and reality; the recalibrating branch is more useful if the role has landed badly |
 
 ---
 

--- a/skills/workshop-facilitation/SKILL.md
+++ b/skills/workshop-facilitation/SKILL.md
@@ -75,12 +75,15 @@ Provide the canonical facilitation pattern for interactive skills: one step at a
 **Facilitator:** "Great. We’ll run Context Design first, with Team-AI Facilitation in parallel."
 
 ## Common Pitfalls
-- Asking multiple questions in the same turn.
-- Offering recommendations after every answer (creates interaction drag).
-- Using shorthand labels without plain-language questions.
-- Hiding progress, so users don't know how much remains.
-- Ignoring the user's chosen option or custom direction.
-- Failing to label assumptions when running in best-guess mode.
+
+| Pitfall | Consequence |
+|---------|-------------|
+| Asking multiple questions in the same turn | Overwhelms user, breaks one-step flow |
+| Offering recommendations after every answer | Creates interaction drag |
+| Using shorthand labels without plain-language questions | Confuses users unfamiliar with internal terms |
+| Hiding progress | Users don't know how much remains |
+| Ignoring the user's chosen option or custom direction | Breaks trust and flow |
+| Failing to label assumptions in best-guess mode | User can't validate inferred context |
 
 ## References
 - Use as the source of truth for interactive facilitation behavior.


### PR DESCRIPTION
Hullo @deanpeters 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/a39f4a44-e5ab-4667-a4cd-d5df7f3a2555" />

Here's the full before/after in text format:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| company-research | 68% | 93% | +25% |
| jobs-to-be-done | 51% | 76% | +25% |
| finance-based-pricing-advisor | 66% | 85% | +19% | 
| prd-development | 63% | 80% | +17% |
| customer-journey-map | 70% | 85% | +15% |
| discovery-interview-prep | 76% | 88% | +12% |
| tam-sam-som-calculator | 81% | 93% | +12% |
| customer-journey-mapping-workshop | 74% | 85% | +11% | 
| opportunity-solution-tree | 69% | 80% | +11% |
| problem-framing-canvas | 69% | 80% | +11% |
| epic-breakdown-advisor | 76% | 84% | +8% |
| prioritization-advisor | 76% | 84% | +8% |
| skill-authoring-workflow | 76% | 84% | +8% |
| roadmap-planning | 65% | 72% | +7% |
| context-engineering-advisor | 55% | 61% | +6% |
| eol-message | 76% | 80% | +4% |
| positioning-workshop | 81% | 85% | +4% |
| saas-economics-efficiency-metrics | 72% | 76% | +4% | 
| storyboard | 72% | 76% | +4% |
| user-story-mapping-workshop | 76% | 80% | +4% |

20 of 46 skills improved, average improvement of +10% across changed skills. No regressions.

<details>
<summary>What changed</summary>

The changes follow a consistent pattern across all improved skills:

- **Consolidated Common Pitfalls into tables**: Converted verbose Symptom/Consequence/Fix blocks into compact markdown tables — same information, ~60% fewer lines
- **Removed redundant "When to Use / When NOT to Use" sections**: The `description` frontmatter already contains trigger-oriented "Use when..." language, making these sections duplicative
- **Removed "Why This Works" explanatory sections**: Educational justification that doesn't help an agent execute the skill
- **Removed "This is not a..." meta-commentary**: Lines like "This is not a Gantt chart" or "This is not a feature spec" add noise without aiding execution
- **Removed "Anti-Patterns (What This Is NOT)" sections**: Redundant with the description's scoping
- **Removed trailing metadata blocks**: Footer blocks duplicating frontmatter (Skill type / Suggested filename / Suggested placement / Dependencies)
- **Condensed Key Concepts**: Replaced verbose roadmap type explanations with a compact reference table (roadmap-planning)
- **Removed educational preambles**: Trimmed sections explaining concepts Claude already knows (e.g., "What is the MITRE Problem Framing Canvas?", "What is a Customer Journey Map?")

All changes preserve the core methodology, domain expertise, cross-references to other skills, and frontmatter fields. No files were renamed or created.

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏