### PR TITLE
security: add input length guard to run-pm.sh

### DIFF
--- a/scripts/run-pm.sh
+++ b/scripts/run-pm.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # run-pm.sh - Fast runner for PM skills and commands
+# NOTE: This is a local development tool. Do not expose it as a service.
 #
 # Usage:
 #   ./scripts/run-pm.sh skill prd-development "Create a PRD for ..."
@@ -52,6 +53,13 @@ parse_args() {
     MODE="$1"
     TARGET="$2"
     INPUT="$3"
+
+    # Guard: reject inputs over 2000 characters to prevent runaway prompts
+    if [[ ${#INPUT} -gt 2000 ]]; then
+        echo "Error: Input exceeds 2000 characters (got ${#INPUT}). Truncate your input and retry." >&2
+        exit 1
+    fi
+
     shift 3
 
     while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug / Security Finding

**File:** `scripts/run-pm.sh`
**Severity:** Medium
**Finding:** User-supplied input (`$3` / argv[3]) is passed directly to the `claude` and `codex` CLI binaries with no length or content validation.

While there is no shell injection risk (the value is passed as a quoted argument, not via `eval`), an unbounded input could send an unexpectedly large prompt to an external AI API, incurring cost or triggering rate limits. This is a local development tool, but the guard is low-effort and clearly communicates the intended usage boundary.

## Fix

- Added an input length guard that rejects inputs exceeding **2000 characters** with a clear error message.
- Added a `NOTE:` header comment documenting that this is a local development tool not intended to be exposed as a service.

## Why It Matters

The fix is two cheap lines that prevent accidental misuse. It also makes the "local dev tool only" intent explicit in the source so future contributors don't inadvertently wrap this script in a web endpoint.

## Diff

```
+    # Guard: reject inputs over 2000 characters to prevent runaway prompts
+    if [[ ${#INPUT} -gt 2000 ]]; then
+        echo "Error: Input exceeds 2000 characters (got ${#INPUT}). Truncate your input and retry." >&2
+        exit 1
+    fi
```

No behavioural change for normal usage — the typical prompt is well under 2000 characters.