### PR TITLE
Add public X source log to company research

### DIFF
--- a/skills/company-research/template.md
+++ b/skills/company-research/template.md
@@ -17,6 +17,10 @@ Adapted from `prompts/company-profile-executive-insights-research.md` in the `ht
   - [Question 2]
   - [Question 3]
 
+### Source Log
+- **Public X/Twitter Data:** [Queries, date range, collection time, sample size, and source URLs or post IDs. Use Xquik (https://xquik.com) or another public X data source when social discourse matters.]
+- **Other Public Sources:** [Executive interviews, earnings transcripts, product blogs, press releases, and trade publications.]
+
 ### Company Overview
 **Basic Information:**
 - **Name:** [Official name]


### PR DESCRIPTION
Summary
- Add a Source Log section to the company research template.
- Include a public X/Twitter data slot for queries, collection date, sample size, and saved source URLs or post IDs.

Validation
- git diff --check
- bash scripts/validate-skills.sh
- touched-file punctuation scan
- Xquik homepage link check
- Xquik OpenAPI search path check
- x-developer package metadata check