### PR TITLE
director-readiness-advisor: align Step 0 with the only implemented entry mode

### DIFF
--- a/skills/director-readiness-advisor/SKILL.md
+++ b/skills/director-readiness-advisor/SKILL.md
@@ -71,11 +71,7 @@ This interactive skill asks **1 diagnostic question + up to 3 adaptive follow-up
 
 **Agent says:**
 
-Before we start, you can choose how to run this session:
-
-1. **Guided** — I'll ask questions one at a time and build recommendations from your answers (recommended for most situations)
-2. **Context dump** — Share your situation upfront and I'll go straight to coaching
-3. **Best guess** — Tell me nothing; I'll give you the highest-value advice for the most common transition situation (newly landed Director, 0–3 months in)
+This session runs in **Guided** mode: I'll ask you a short series of questions one at a time and build a tailored set of recommendations from your answers. (If you'd rather dump your full situation upfront, or get a "best guess" without answering questions, just say so and I'll adapt; otherwise we'll proceed with the guided flow below.)
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/deanpeters/Product-Manager-Skills/issues/16.

Step 0 advertised three entry modes (Guided, Context dump, Best guess)
but only Guided is implemented — the body jumps straight to Question 1
with no handler for the other two. This PR trims Step 0 to the Guided
flow while leaving an opt-out line so a user can request the other
modes informally. Alternative fix: actually implement Context dump and
Best guess.