### PR TITLE
Add OpenCode runtime compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 ║   ╚═╝     ╚═╝     ╚═╝    ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝
 ║                                                                    ║
 ║   55 battle-tested skills + 6 command workflows                    ║
-║   Claude Code • Cursor • Codex  • n8n • OpenClaw • and more ...    ║
+║   Claude Code • Cursor • Codex  • n8n • OpenClaw • OpenCode • ...  ║
 ║                                                                    ║
 ║   v0.81 • July 4, 2026 • CC BY-NC-SA 4.0                           ║
 ╚════════════════════════════════════════════════════════════════════╝
 ```
 
-**55 battle-tested PM frameworks, ready for Claude, Codex, ChatGPT, and any agent that can read structured knowledge.**
+**55 battle-tested PM frameworks, ready for Claude, Codex, ChatGPT, OpenCode, and any agent that can read structured knowledge.**
 
 ---
 
@@ -94,6 +94,7 @@ Choose your setup:
 | Claude Desktop or Claude Web | [`pm-skills-starter-pack.zip`](https://github.com/deanpeters/Product-Manager-Skills/releases/latest/download/pm-skills-starter-pack.zip) | Unzip, then upload the individual skill ZIPs to Claude Skills |
 | Claude Code | Plugin marketplace | `claude /plugin marketplace add deanpeters/Product-Manager-Skills` |
 | Codex | [`pm-skills-codex.zip`](https://github.com/deanpeters/Product-Manager-Skills/releases/latest/download/pm-skills-codex.zip) | Installs `.agents/skills` and `AGENTS.md` |
+| OpenCode | Global: `cp -r skills/* ~/.config/opencode/skills/` | opencode discovers `.claude/skills/` and `~/.config/opencode/skills/` natively. Uses `metadata` frontmatter. |
 | Not sure | [`pm-skills-starter-pack.zip`](https://github.com/deanpeters/Product-Manager-Skills/releases/latest/download/pm-skills-starter-pack.zip) | Start here |
 
 **All downloads:** [GitHub Releases](https://github.com/deanpeters/Product-Manager-Skills/releases/latest)
@@ -116,6 +117,7 @@ Each pack below is a ZIP of upload-ready skill ZIPs — unzip, then upload indiv
 - [Claude Desktop / Web](docs/INSTALL-CLAUDE-DESKTOP.md)
 - [Claude Code](docs/INSTALL-CLAUDE-CODE.md)
 - [Codex](docs/INSTALL-CODEX.md)
+- [OpenCode](docs/INSTALL-OPENCODE.md)
 - [Platform chooser for non-technical PMs](docs/PM%20Skills%20Rule-of-Thumb%20Guide.md)
 
 ---
@@ -178,7 +180,7 @@ Every `SKILL.md` follows the same structure:
 
 | Section | What it contains |
 |---|---|
-| **Frontmatter** | `name`, `description`, `type`, `intent`, `best_for`, `scenarios` |
+| **Frontmatter** | `name`, `description`, `compatibility`, `type`, `intent`, `best_for`, `scenarios`, `metadata` |
 | **Purpose** | What this skill does and when to reach for it |
 | **Input** | What you *can* bring (with example invocations) — inline input is used, not re-asked, and arriving empty-handed is fine: the skill walks you through it |
 | **Key Concepts** | Frameworks, definitions, anti-patterns — with vocabulary explained |
@@ -195,7 +197,7 @@ The `best_for` frontmatter field lists 3-5 specific scenarios where the skill is
 
 ## Works With
 
-Claude Code · Claude Desktop · Claude Web · OpenAI Codex · ChatGPT · Cursor · Windsurf · n8n · LangFlow · CrewAI · Gemini · any agent that reads structured markdown
+Claude Code · Claude Desktop · Claude Web · OpenAI Codex · ChatGPT · Cursor · Windsurf · n8n · LangFlow · CrewAI · Gemini · OpenCode · any agent that reads structured markdown
 
 See [docs/Platform Guides for PMs.md](docs/Platform%20Guides%20for%20PMs.md) for platform-specific setup.
 
@@ -209,6 +211,7 @@ See [docs/Platform Guides for PMs.md](docs/Platform%20Guides%20for%20PMs.md) for
 | [Platform Guides for PMs](docs/Platform%20Guides%20for%20PMs.md) | Tool-by-tool setup chooser for every supported platform |
 | [Using PM Skills with Claude](docs/Using%20PM%20Skills%20with%20Claude.md) | Claude Code + GitHub ZIP upload for Claude Desktop/Web |
 | [Using PM Skills with Codex](docs/Using%20PM%20Skills%20with%20Codex.md) | Local workspace + GitHub-connected Codex on ChatGPT |
+| [Using PM Skills with OpenCode](docs/INSTALL-OPENCODE.md) | Global `~/.config/opencode/skills/` or project `.opencode/skills/` |
 | [Using PM Skills with ChatGPT](docs/Using%20PM%20Skills%20with%20ChatGPT.md) | GitHub app, Custom GPT Knowledge, and Project-based usage |
 | [Using PM Skills with Slash Commands 101](docs/Using%20PM%20Skills%20with%20Slash%20Commands%20101.md) | Turn skills into reusable slash commands like `/pm-story` |
 | [Add-a-Skill Utility Guide](docs/Add-a-Skill%20Utility%20Guide.md) | End-to-end guide for generating and validating new skills |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -46,6 +46,7 @@ Start with:
 - `Claude Code`: `docs/Using PM Skills with Claude Code.md`
 - `Claude /slash commands`: `docs/Using PM Skills with Slash Commands 101.md`
 - `Codex`: `docs/Using PM Skills with Codex.md`
+- `OpenCode`: `docs/INSTALL-OPENCODE.md`
 
 Copy/paste starter prompt:
 

--- a/docs/INSTALL-OPENCODE.md
+++ b/docs/INSTALL-OPENCODE.md
@@ -1,0 +1,57 @@
+# Install PM Skills for OpenCode
+
+[OpenCode](https://opencode.ai) is an AI coding agent that natively discovers skills from your home directory or project.
+
+## Global Install (all projects)
+
+```bash
+# Copy all skills to OpenCode's global skills directory
+cp -r skills/* ~/.config/opencode/skills/
+
+# Or copy individual skills:
+cp -r skills/prd-development ~/.config/opencode/skills/
+cp -r skills/user-story ~/.config/opencode/skills/
+```
+
+## Project-level Install
+
+```bash
+# From your project root
+cp -r ../Product-Manager-Skills/skills/* .opencode/skills/
+```
+
+## How It Works
+
+OpenCode discovers skills from these locations (in order):
+
+1. `.opencode/skills/<name>/SKILL.md` (project)
+2. `~/.config/opencode/skills/<name>/SKILL.md` (global)
+3. `.claude/skills/<name>/SKILL.md` (project, Claude-compatible fallback)
+4. `~/.claude/skills/<name>/SKILL.md` (global, Claude-compatible fallback)
+
+Skills are loaded on-demand via OpenCode's `skill` tool — the agent sees all available skills and loads the full content when needed.
+
+## Per-Agent Permissions (optional)
+
+In your `opencode.json`, scope PM skills to specific agents:
+
+```json
+{
+  "agent": {
+    "plan": {
+      "permission": {
+        "skill": {
+          "pm-*": "allow",
+          "user-story*": "allow",
+          "prd-*": "allow",
+          "stakeholder-*": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+## OpenCode-Specific Frontmatter
+
+These skills include `compatibility: opencode` and rich fields nested under `metadata:` — OpenCode reads `name` and `description` for skill selection, and agents can read `metadata.*` fields at runtime for additional context.

--- a/scripts/add-opencode-compat.py
+++ b/scripts/add-opencode-compat.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Add opencode compatibility frontmatter to all 55 SKILL.md files.
+
+- Inserts `compatibility: opencode`
+- Nests rich fields (intent, type, theme, best_for, scenarios,
+  estimated_time, sources) under `metadata:`
+- Preserves `name`, `description`, `argument-hint` as top-level
+- Keeps body content (after `---` closing) unchanged
+- Writes files in-place
+"""
+
+import os
+import sys
+from ruamel.yaml import YAML
+
+SKILLS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "skills")
+
+META_FIELDS = {
+    "intent",
+    "type",
+    "theme",
+    "best_for",
+    "scenarios",
+    "estimated_time",
+    "sources",
+}
+TOP_FIELDS = {"name", "description", "argument-hint"}
+
+yaml = YAML()
+yaml.preserve_quotes = True
+yaml.width = 200
+yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+def transform_skill(skill_dir: str) -> bool:
+    skill_path = os.path.join(skill_dir, "SKILL.md")
+    if not os.path.isfile(skill_path):
+        print(f"  SKIP (no SKILL.md): {skill_path}")
+        return False
+
+    with open(skill_path, "r") as f:
+        raw = f.read()
+
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        print(f"  SKIP (bad frontmatter): {skill_path}")
+        return False
+
+    fm_raw = parts[1]
+    body = parts[2]
+
+    fm_data = yaml.load(fm_raw)
+    if fm_data is None:
+        fm_data = {}
+
+    if fm_data.get("compatibility") == "opencode":
+        print(f"  SKIP (already compatible): {skill_path}")
+        return False
+
+    metadata = {}
+    new_fm = {}
+
+    for key, value in fm_data.items():
+        if key in META_FIELDS:
+            metadata[key] = value
+        else:
+            new_fm[key] = value
+
+    new_fm["compatibility"] = "opencode"
+
+    if metadata:
+        # insert metadata after argument-hint (if present) or after description
+        # Build ordered dict-ish approach: compose YAML string manually
+        pass
+
+    # Build the final frontmatter as a composed mapping that preserves order
+    final = yaml.map()
+    final["name"] = new_fm.pop("name")
+    final["description"] = new_fm.pop("description")
+    final["compatibility"] = "opencode"
+
+    if "argument-hint" in new_fm:
+        final["argument-hint"] = new_fm.pop("argument-hint")
+
+    if metadata:
+        md = yaml.map()
+        for k in sorted(metadata.keys()):
+            md[k] = metadata[k]
+        final["metadata"] = md
+
+    for k in new_fm:
+        final[k] = new_fm[k]
+
+    from io import StringIO
+    buf = StringIO()
+    yaml.dump(final, buf)
+    new_fm_str = buf.getvalue().rstrip("\n")
+
+    new_raw = f"---\n{new_fm_str}\n---{body}"
+
+    with open(skill_path, "w") as f:
+        f.write(new_raw)
+
+    print(f"  OK: {skill_path}")
+    return True
+
+
+def main():
+    skills = sorted(os.listdir(SKILLS_DIR))
+    changed = 0
+    skipped = 0
+
+    for skill_name in skills:
+        skill_dir = os.path.join(SKILLS_DIR, skill_name)
+        if not os.path.isdir(skill_dir):
+            continue
+        result = transform_skill(skill_dir)
+        if result:
+            changed += 1
+        else:
+            skipped += 1
+
+    print(f"\nDone. Changed: {changed}, Skipped: {skipped}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-skill-metadata.py
+++ b/scripts/check-skill-metadata.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Validate skill conformance for repository and Claude compatibility.
+"""Validate skill conformance for repository, Claude, and OpenCode compatibility.
 
 Checks:
 - Valid YAML frontmatter
 - name present, lowercase kebab-case, and <= 64 chars
 - description present and <= 200 chars
-- intent present and non-empty
-- type present and one of: component, interactive, workflow
+- intent present and non-empty (top-level or under metadata)
+- type present and one of: component, interactive, workflow (top-level or under metadata)
 - folder name matches frontmatter name
+- compatibility field accepted when present (opencode supported)
+- metadata field accepted as optional nested map
 - required sections exist in order:
   Purpose, Input, Key Concepts, Application, Examples, Common Pitfalls, References
 - no $ARGUMENTS template syntax in the body (outside code formatting) — skills
@@ -122,10 +124,12 @@ def check_skill(path: str) -> list[Issue]:
         issues.append(Issue(path, "frontmatter_missing", "Missing or malformed frontmatter"))
         return issues
 
+    metadata = data.get("metadata") or {}
+
     name = str(data.get("name") or "").strip()
     description = str(data.get("description") or "").strip()
-    intent = str(data.get("intent") or "").strip()
-    skill_type = str(data.get("type") or "").strip()
+    intent = str(metadata.get("intent") or data.get("intent") or "").strip()
+    skill_type = str(metadata.get("type") or data.get("type") or "").strip()
 
     if not name:
         issues.append(Issue(path, "name_missing", "Frontmatter name is required"))

--- a/skills/acquisition-channel-advisor/SKILL.md
+++ b/skills/acquisition-channel-advisor/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: acquisition-channel-advisor
-argument-hint: "[channel to evaluate]"
 description: Evaluate acquisition channels using unit economics, customer quality, and scalability. Use when deciding whether to scale, test, or kill a growth channel.
-intent: >-
-  Guide product managers through evaluating whether to scale, test, or kill an acquisition channel based on unit economics (CAC, LTV, payback), customer quality (retention, NRR), and scalability (magic number, volume potential). Use this to make data-driven go-to-market decisions and optimize channel mix for sustainable growth.
-type: interactive
-best_for:
-  - "Deciding whether a paid or outbound channel deserves more budget"
-  - "Comparing channel quality, payback, and scalability side by side"
-  - "Making scale, test, or kill decisions with finance-backed reasoning"
-scenarios:
-  - "Should we keep investing in paid LinkedIn ads for enterprise leads?"
-  - "Compare content marketing, outbound email, and partner referrals as acquisition channels"
-  - "Help me decide whether to scale or kill our webinar acquisition channel"
+compatibility: opencode
+argument-hint: "[channel to evaluate]"
+metadata:
+  best_for:
+    - "Deciding whether a paid or outbound channel deserves more budget"
+    - "Comparing channel quality, payback, and scalability side by side"
+    - "Making scale, test, or kill decisions with finance-backed reasoning"
+  intent: >-
+    Guide product managers through evaluating whether to scale, test, or kill an acquisition channel based on unit economics (CAC, LTV, payback), customer quality (retention, NRR), and scalability (magic
+    number, volume potential). Use this to make data-driven go-to-market decisions and optimize channel mix for sustainable growth.
+  scenarios:
+    - "Should we keep investing in paid LinkedIn ads for enterprise leads?"
+    - "Compare content marketing, outbound email, and partner referrals as acquisition channels"
+    - "Help me decide whether to scale or kill our webinar acquisition channel"
+  type: interactive
 ---
 
 

--- a/skills/agent-orchestration-advisor/SKILL.md
+++ b/skills/agent-orchestration-advisor/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: agent-orchestration-advisor
-argument-hint: "[workflow or task to orchestrate]"
 description: Design multi-agent AI workflows with clear boundaries, handoffs, and monitoring. Use when a complex PM task should run as parallel specialized agents instead of one linear process.
-intent: >-
-  Guide product managers through designing multi-agent workflows — breaking complex, repetitive tasks into parallel, specialized AI agents rather than linear, sequential processes. Covers the 4 dimensions of orchestration, agent boundary design, launch control tower monitoring, and evaluation frameworks.
-type: interactive
-theme: ai-agents
-best_for:
-  - "Breaking a complex PM workflow into parallel, specialized AI agents"
-  - "Designing agent boundaries, handoffs, and human review points"
-  - "Setting up launch control tower monitoring for agentic workflows"
-scenarios:
-  - "I spend hours on competitive research every week — help me design agents to run it in parallel"
-  - "Our AI workflow is one giant sequential prompt chain — help me re-architect it as an orchestrated system"
-estimated_time: "15-25 min"
+compatibility: opencode
+argument-hint: "[workflow or task to orchestrate]"
+metadata:
+  best_for:
+    - "Breaking a complex PM workflow into parallel, specialized AI agents"
+    - "Designing agent boundaries, handoffs, and human review points"
+    - "Setting up launch control tower monitoring for agentic workflows"
+  estimated_time: "15-25 min"
+  intent: >-
+    Guide product managers through designing multi-agent workflows — breaking complex, repetitive tasks into parallel, specialized AI agents rather than linear, sequential processes. Covers the 4 dimensions
+    of orchestration, agent boundary design, launch control tower monitoring, and evaluation frameworks.
+  scenarios:
+    - "I spend hours on competitive research every week — help me design agents to run it in parallel"
+    - "Our AI workflow is one giant sequential prompt chain — help me re-architect it as an orchestrated system"
+  theme: ai-agents
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/ai-shaped-readiness-advisor/SKILL.md
+++ b/skills/ai-shaped-readiness-advisor/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: ai-shaped-readiness-advisor
-argument-hint: "[team or workflow context]"
 description: Assess whether your product work is AI-first or AI-shaped. Use when evaluating AI maturity and choosing the next team capability to build.
-intent: >-
-  Assess whether your product work is **"AI-first"** (using AI to automate existing tasks faster) or **"AI-shaped"** (fundamentally redesigning how product teams operate around AI capabilities). Use this to evaluate your readiness across **5 essential PM competencies for 2026**, identify gaps, and get concrete recommendations on which capability to build first.
-type: interactive
-theme: ai-agents
-best_for:
-  - "Assessing whether your team is AI-first or genuinely AI-shaped"
-  - "Identifying which of the 5 AI competencies to build next"
-  - "Understanding your product org's AI maturity honestly"
-scenarios:
-  - "My team uses AI tools but I'm not sure if we're working differently or just automating the same tasks"
-  - "I want to assess my product org's AI maturity and prioritize where to invest next quarter"
-estimated_time: "15-20 min"
+compatibility: opencode
+argument-hint: "[team or workflow context]"
+metadata:
+  best_for:
+    - "Assessing whether your team is AI-first or genuinely AI-shaped"
+    - "Identifying which of the 5 AI competencies to build next"
+    - "Understanding your product org's AI maturity honestly"
+  estimated_time: "15-20 min"
+  intent: >-
+    Assess whether your product work is **"AI-first"** (using AI to automate existing tasks faster) or **"AI-shaped"** (fundamentally redesigning how product teams operate around AI capabilities). Use this
+    to evaluate your readiness across **5 essential PM competencies for 2026**, identify gaps, and get concrete recommendations on which capability to build first.
+  scenarios:
+    - "My team uses AI tools but I'm not sure if we're working differently or just automating the same tasks"
+    - "I want to assess my product org's AI maturity and prioritize where to invest next quarter"
+  theme: ai-agents
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/altitude-horizon-framework/SKILL.md
+++ b/skills/altitude-horizon-framework/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: altitude-horizon-framework
 description: Understand the PM-to-Director transition through altitude and horizon thinking. Use when diagnosing scope, time-horizon, or leadership-level gaps.
-intent: >-
-  Defines the two-axis mental model that distinguishes Director-level thinking from PM thinking: **Altitude** (how wide you zoom out) and **Horizon** (how far ahead you look). Use this to understand what actually changes in the transition, diagnose which transition zone is creating friction, and apply the Cascading Context Map when organizational direction is vague or absent.
-type: component
-theme: career-leadership
-best_for:
-   - "Understanding what actually changes when you move from PM to Director"
-   - "Diagnosing which transition zone is creating friction in your role"
-   - "Applying the Cascading Context Map when organizational direction is vague"
-scenarios:
-   - "I'm a senior PM trying to understand what changes when I become a Director"
-   - "I'm newly promoted to Director and something isn't clicking — help me diagnose it"
-   - "My team has no clear direction and I need to create context from a vague company strategy"
-estimated_time: "10-15 min"
+compatibility: opencode
+metadata:
+  best_for:
+    - "Understanding what actually changes when you move from PM to Director"
+    - "Diagnosing which transition zone is creating friction in your role"
+    - "Applying the Cascading Context Map when organizational direction is vague"
+  estimated_time: "10-15 min"
+  intent: >-
+    Defines the two-axis mental model that distinguishes Director-level thinking from PM thinking: **Altitude** (how wide you zoom out) and **Horizon** (how far ahead you look). Use this to understand what
+    actually changes in the transition, diagnose which transition zone is creating friction, and apply the Cascading Context Map when organizational direction is vague or absent.
+  scenarios:
+    - "I'm a senior PM trying to understand what changes when I become a Director"
+    - "I'm newly promoted to Director and something isn't clicking — help me diagnose it"
+    - "My team has no clear direction and I need to create context from a vague company strategy"
+  theme: career-leadership
+  type: component
 ---
 
 ## Purpose

--- a/skills/business-health-diagnostic/SKILL.md
+++ b/skills/business-health-diagnostic/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: business-health-diagnostic
-argument-hint: "[metrics or business context]"
 description: Diagnose SaaS business health across growth, retention, efficiency, and capital. Use when preparing a business review or prioritizing urgent fixes.
-intent: >-
-  Diagnose overall SaaS business health by analyzing growth, retention, unit economics, and capital efficiency metrics together. Use this to identify problems early, prioritize actions by urgency, and deliver a comprehensive health scorecard for board meetings, quarterly reviews, or fundraising preparation.
-type: interactive
-theme: finance-metrics
-best_for:
-  - "Getting a complete read on your SaaS business health across all dimensions"
-  - "Identifying which metrics are red flags vs. leading indicators"
-  - "Preparing for a board meeting or investor review"
-scenarios:
-  - "Our growth is strong but we're burning cash fast — I need to understand our unit economics before the board meeting"
-  - "I'm preparing for a Series A board meeting and need to assess our business health across growth, retention, and efficiency"
-estimated_time: "20-30 min"
+compatibility: opencode
+argument-hint: "[metrics or business context]"
+metadata:
+  best_for:
+    - "Getting a complete read on your SaaS business health across all dimensions"
+    - "Identifying which metrics are red flags vs. leading indicators"
+    - "Preparing for a board meeting or investor review"
+  estimated_time: "20-30 min"
+  intent: >-
+    Diagnose overall SaaS business health by analyzing growth, retention, unit economics, and capital efficiency metrics together. Use this to identify problems early, prioritize actions by urgency, and
+    deliver a comprehensive health scorecard for board meetings, quarterly reviews, or fundraising preparation.
+  scenarios:
+    - "Our growth is strong but we're burning cash fast — I need to understand our unit economics before the board meeting"
+    - "I'm preparing for a Series A board meeting and need to assess our business health across growth, retention, and efficiency"
+  theme: finance-metrics
+  type: interactive
 ---
 
 

--- a/skills/company-intel/SKILL.md
+++ b/skills/company-intel/SKILL.md
@@ -1,28 +1,30 @@
 ---
 name: company-intel
-argument-hint: "[company, industry, or competitor set]"
 description: Research a company, industry, or competitor set using web search and seven analytical lenses. Use when you need structured intel that feeds downstream PM skills.
-intent: >-
-  Act as a research engine that builds deep, structured understanding of companies, industries,
-  and competitor sets through **seven analytical lenses** — financial landscape, market offer,
-  product portfolio, competitive dynamics, rising trends, PM implications, and strategic signals
-  (patents, hiring, leadership). Produces a stable, structured output that downstream skills
-  consume to generate battlecards, SWOT analyses, positioning statements, PESTEL assessments,
-  and market sizing. Supports four entry points: single company, industry/sector, named competitor
-  set, or company + "discover my competitors" (researches the company first, identifies likely
-  competitors, confirms the list, then runs the full competitor set analysis).
-type: workflow
-best_for:
-  - "Building deep company or industry knowledge before a client engagement or workshop"
-  - "Generating structured research that feeds battlecards, SWOT, positioning, or PESTEL"
-  - "Running a competitive scan across 3-5 companies with cross-company comparison"
-  - "Refreshing intel quarterly on companies you track"
-scenarios:
-  - "Run company-intel on Parker Hannifin"
-  - "Give me intel on the clinical data management industry"
-  - "Compare Emerson, Honeywell, and Parker Hannifin"
-  - "Run company-intel on productside.com competitors"
-  - "Refresh my intel on Novo Nordisk — what's changed since last quarter?"
+compatibility: opencode
+argument-hint: "[company, industry, or competitor set]"
+metadata:
+  best_for:
+    - "Building deep company or industry knowledge before a client engagement or workshop"
+    - "Generating structured research that feeds battlecards, SWOT, positioning, or PESTEL"
+    - "Running a competitive scan across 3-5 companies with cross-company comparison"
+    - "Refreshing intel quarterly on companies you track"
+  intent: >-
+    Act as a research engine that builds deep, structured understanding of companies, industries,
+    and competitor sets through **seven analytical lenses** — financial landscape, market offer,
+    product portfolio, competitive dynamics, rising trends, PM implications, and strategic signals
+    (patents, hiring, leadership). Produces a stable, structured output that downstream skills
+    consume to generate battlecards, SWOT analyses, positioning statements, PESTEL assessments,
+    and market sizing. Supports four entry points: single company, industry/sector, named competitor
+    set, or company + "discover my competitors" (researches the company first, identifies likely
+    competitors, confirms the list, then runs the full competitor set analysis).
+  scenarios:
+    - "Run company-intel on Parker Hannifin"
+    - "Give me intel on the clinical data management industry"
+    - "Compare Emerson, Honeywell, and Parker Hannifin"
+    - "Run company-intel on productside.com competitors"
+    - "Refresh my intel on Novo Nordisk — what's changed since last quarter?"
+  type: workflow
 ---
 
 ## Purpose

--- a/skills/company-research/SKILL.md
+++ b/skills/company-research/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: company-research
-argument-hint: "[company name] [purpose]"
 description: Create a company research brief with executive quotes, product strategy, and org context. Use when preparing for interviews, competitive analysis, partnerships, or market-entry work.
-intent: >-
-  Create a comprehensive company profile that extracts executive insights, product strategy, transformation initiatives, and organizational dynamics from publicly available sources. Use this to understand competitive landscape, evaluate partnership opportunities, benchmark best practices, prepare for interviews, or inform market entry decisions by understanding how successful companies think about product management and strategy.
-type: component
+compatibility: opencode
+argument-hint: "[company name] [purpose]"
+metadata:
+  intent: >-
+    Create a comprehensive company profile that extracts executive insights, product strategy, transformation initiatives, and organizational dynamics from publicly available sources. Use this to understand
+    competitive landscape, evaluate partnership opportunities, benchmark best practices, prepare for interviews, or inform market entry decisions by understanding how successful companies think about product
+    management and strategy.
+  type: component
 ---
 
 

--- a/skills/context-engineering-advisor/SKILL.md
+++ b/skills/context-engineering-advisor/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: context-engineering-advisor
-argument-hint: "[AI workflow to diagnose]"
 description: Diagnose context stuffing vs. context engineering. Use when an AI workflow feels bloated, brittle, or hard to steer reliably.
-intent: >-
-  Guide product managers through diagnosing whether they're doing **context stuffing** (jamming volume without intent) or **context engineering** (shaping structure for attention). Use this to identify context boundaries, fix "Context Hoarding Disorder," and implement tactical practices like bounded domains, episodic retrieval, and the Research→Plan→Reset→Implement cycle.
-type: interactive
-theme: ai-agents
-best_for:
-  - "Diagnosing context stuffing vs. context engineering in your AI workflows"
-  - "Building better memory and retrieval architecture for AI agents"
-  - "Improving AI output quality through structured context design"
-scenarios:
-  - "My AI outputs are mediocre even though I'm giving it lots of information — diagnose what's wrong"
-  - "I want to architect context properly for a multi-step AI workflow in my product team"
-estimated_time: "15-20 min"
+compatibility: opencode
+argument-hint: "[AI workflow to diagnose]"
+metadata:
+  best_for:
+    - "Diagnosing context stuffing vs. context engineering in your AI workflows"
+    - "Building better memory and retrieval architecture for AI agents"
+    - "Improving AI output quality through structured context design"
+  estimated_time: "15-20 min"
+  intent: >-
+    Guide product managers through diagnosing whether they're doing **context stuffing** (jamming volume without intent) or **context engineering** (shaping structure for attention). Use this to identify
+    context boundaries, fix "Context Hoarding Disorder," and implement tactical practices like bounded domains, episodic retrieval, and the Research→Plan→Reset→Implement cycle.
+  scenarios:
+    - "My AI outputs are mediocre even though I'm giving it lots of information — diagnose what's wrong"
+    - "I want to architect context properly for a multi-step AI workflow in my product team"
+  theme: ai-agents
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/customer-journey-map/SKILL.md
+++ b/skills/customer-journey-map/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: customer-journey-map
-argument-hint: "[persona] [scenario]"
 description: Create a customer journey map across stages, touchpoints, actions, emotions, and metrics. Use when diagnosing a broken experience or aligning a team on the full customer flow.
-intent: >-
-  Create a comprehensive customer journey map that visualizes how customers interact with your brand across all stages—from awareness to loyalty—documenting their actions, touchpoints, emotions, KPIs, business goals, and teams involved at each stage. Use this to identify pain points, align cross-functional teams, and systematically improve the customer experience to achieve business objectives.
-type: component
-theme: workshops-facilitation
-best_for:
-  - "Mapping the full customer experience across all touchpoints"
-  - "Aligning cross-functional teams on the end-to-end customer journey"
-  - "Identifying pain points and opportunities by stage with measurable KPIs"
-scenarios:
-  - "I need to map the customer journey for our B2B SaaS onboarding experience from signup to first value"
-  - "Create a journey map for a PM leader evaluating our skills repo — from discovery through loyalty"
-estimated_time: "20-30 min"
+compatibility: opencode
+argument-hint: "[persona] [scenario]"
+metadata:
+  best_for:
+    - "Mapping the full customer experience across all touchpoints"
+    - "Aligning cross-functional teams on the end-to-end customer journey"
+    - "Identifying pain points and opportunities by stage with measurable KPIs"
+  estimated_time: "20-30 min"
+  intent: >-
+    Create a comprehensive customer journey map that visualizes how customers interact with your brand across all stages—from awareness to loyalty—documenting their actions, touchpoints, emotions, KPIs,
+    business goals, and teams involved at each stage. Use this to identify pain points, align cross-functional teams, and systematically improve the customer experience to achieve business objectives.
+  scenarios:
+    - "I need to map the customer journey for our B2B SaaS onboarding experience from signup to first value"
+    - "Create a journey map for a PM leader evaluating our skills repo — from discovery through loyalty"
+  theme: workshops-facilitation
+  type: component
 ---
 
 

--- a/skills/customer-journey-mapping-workshop/SKILL.md
+++ b/skills/customer-journey-mapping-workshop/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: customer-journey-mapping-workshop
-argument-hint: "[persona] [scenario]"
 description: Run a customer journey mapping workshop with adaptive questions and outputs. Use when you need to map stages, actions, emotions, pain points, and opportunities for a persona and scenario.
-intent: >-
-  Guide product managers through creating a customer journey map by asking adaptive questions about the actor (persona), scenario/goal, journey phases, actions/emotions, and opportunities for improvement. Use this to visualize the end-to-end customer experience, identify pain points, and create a shared mental model across teams—avoiding surface-level feature lists and ensuring discovery work focuses on real customer problems, not assumed solutions.
-type: interactive
-best_for:
-  - "Running a workshop to map an end-to-end customer experience"
-  - "Finding pain points across a user's journey"
-  - "Aligning teams on the stages, emotions, and breakdowns in an experience"
-scenarios:
-  - "Help me run a journey mapping workshop for new customer onboarding"
-  - "Map the experience of a buyer from trial signup to first value"
-  - "Facilitate a workshop on the support journey for churn-risk customers"
+compatibility: opencode
+argument-hint: "[persona] [scenario]"
+metadata:
+  best_for:
+    - "Running a workshop to map an end-to-end customer experience"
+    - "Finding pain points across a user's journey"
+    - "Aligning teams on the stages, emotions, and breakdowns in an experience"
+  intent: >-
+    Guide product managers through creating a customer journey map by asking adaptive questions about the actor (persona), scenario/goal, journey phases, actions/emotions, and opportunities for improvement.
+    Use this to visualize the end-to-end customer experience, identify pain points, and create a shared mental model across teams—avoiding surface-level feature lists and ensuring discovery work focuses
+    on real customer problems, not assumed solutions.
+  scenarios:
+    - "Help me run a journey mapping workshop for new customer onboarding"
+    - "Map the experience of a buyer from trial signup to first value"
+    - "Facilitate a workshop on the support journey for churn-risk customers"
+  type: interactive
 ---
 
 

--- a/skills/derisk-measurement-advisor/SKILL.md
+++ b/skills/derisk-measurement-advisor/SKILL.md
@@ -1,26 +1,28 @@
 ---
 name: derisk-measurement-advisor
-argument-hint: "[product or AI idea]"
 description: Identify what to measure, test, or track to de-risk a product or AI idea. Use when stress-testing an idea across internal (DUFV) and external (PESTEL) dimensions.
-intent: >-
-  Guide product managers through a structured risk scan across **10 dimensions** — 4 internal
-  (Desirability, Usability, Feasibility, Viability) and 6 external (Political, Economic, Social,
-  Technological, Environmental, Legal) — to identify the most important things to measure, test,
-  or track before committing to a product or AI idea. Each surfaced risk gets triaged into
-  **act on immediately** or **start tracking**, producing a prioritized risk register with
-  concrete next steps.
-type: interactive
-best_for:
-  - "Stress-testing an AI or product idea before putting it on the roadmap"
-  - "Identifying the cheapest tests to run before committing teams and budget"
-  - "Scanning for external forces that could blindside your product plans"
-  - "Building a risk register with clear act-now vs. watch-and-track priorities"
-scenarios:
-  - "I have an AI product idea. What should I measure before we commit?"
-  - "Help me figure out what risks to act on now vs. track over time"
-  - "We're about to put this on the roadmap. What could go wrong internally and externally?"
-  - "Is this idea worth the squeeze? What should we test first?"
-estimated_time: "15-20 min"
+compatibility: opencode
+argument-hint: "[product or AI idea]"
+metadata:
+  best_for:
+    - "Stress-testing an AI or product idea before putting it on the roadmap"
+    - "Identifying the cheapest tests to run before committing teams and budget"
+    - "Scanning for external forces that could blindside your product plans"
+    - "Building a risk register with clear act-now vs. watch-and-track priorities"
+  estimated_time: "15-20 min"
+  intent: >-
+    Guide product managers through a structured risk scan across **10 dimensions** — 4 internal
+    (Desirability, Usability, Feasibility, Viability) and 6 external (Political, Economic, Social,
+    Technological, Environmental, Legal) — to identify the most important things to measure, test,
+    or track before committing to a product or AI idea. Each surfaced risk gets triaged into
+    **act on immediately** or **start tracking**, producing a prioritized risk register with
+    concrete next steps.
+  scenarios:
+    - "I have an AI product idea. What should I measure before we commit?"
+    - "Help me figure out what risks to act on now vs. track over time"
+    - "We're about to put this on the roadmap. What could go wrong internally and externally?"
+    - "Is this idea worth the squeeze? What should we test first?"
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/director-readiness-advisor/SKILL.md
+++ b/skills/director-readiness-advisor/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: director-readiness-advisor
-argument-hint: "[where you are: preparing | interviewing | landed | recalibrating]"
 description: Guide the PM-to-Director transition across preparing, interviewing, landing, and recalibrating. Use when leadership scope is changing and you need practical coaching.
-intent: >-
-  Guide PMs and Directors through the specific challenges of the PM-to-Director transition using adaptive questions and targeted coaching. Diagnoses where you are in the journey and delivers practical, war-story-backed guidance calibrated to your situation — not generic leadership advice.
-type: interactive
-theme: career-leadership
-best_for:
-  - "Preparing to make the leap to Director over the next 3-12 months"
-  - "Navigating your first 6 months in a new Director role"
-  - "Diagnosing what isn't working 12+ months into the Director role"
-scenarios:
-  - "I'm a senior PM preparing for Director interviews next quarter"
-  - "I just got promoted to Director and I can't stop jumping into the tactical work"
-  - "I've been a Director for 18 months and my exec relationships aren't working"
-estimated_time: "10-15 min"
+compatibility: opencode
+argument-hint: "[where you are: preparing | interviewing | landed | recalibrating]"
+metadata:
+  best_for:
+    - "Preparing to make the leap to Director over the next 3-12 months"
+    - "Navigating your first 6 months in a new Director role"
+    - "Diagnosing what isn't working 12+ months into the Director role"
+  estimated_time: "10-15 min"
+  intent: >-
+    Guide PMs and Directors through the specific challenges of the PM-to-Director transition using adaptive questions and targeted coaching. Diagnoses where you are in the journey and delivers practical,
+    war-story-backed guidance calibrated to your situation — not generic leadership advice.
+  scenarios:
+    - "I'm a senior PM preparing for Director interviews next quarter"
+    - "I just got promoted to Director and I can't stop jumping into the tactical work"
+    - "I've been a Director for 18 months and my exec relationships aren't working"
+  theme: career-leadership
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/discovery-interview-prep/SKILL.md
+++ b/skills/discovery-interview-prep/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: discovery-interview-prep
-argument-hint: "[research goal]"
 description: Plan customer discovery interviews with the right goal, segment, constraints, and method. Use when preparing interviews for problem validation, churn research, or new product ideas.
-intent: >-
-  Guide product managers through preparing for customer discovery interviews by asking adaptive questions about research goals, customer segments, constraints, and methodologies. Use this to design effective interview plans, craft targeted questions, avoid common biases, and maximize learning from limited customer access—ensuring discovery interviews yield actionable insights rather than confirmation bias or surface-level feedback.
-type: interactive
-theme: discovery-research
-best_for:
-  - "Designing a customer discovery interview plan"
-  - "Choosing the right interview methodology for your goals and constraints"
-  - "Preparing for research with limited customer access"
-scenarios:
-  - "I need to interview 5 enterprise customers about why they churned in the last 90 days"
-  - "I'm validating a new product idea with a 2-week deadline and cold outreach only"
-  - "I want to understand why users aren't activating on our core feature"
-estimated_time: "15-20 min"
+compatibility: opencode
+argument-hint: "[research goal]"
+metadata:
+  best_for:
+    - "Designing a customer discovery interview plan"
+    - "Choosing the right interview methodology for your goals and constraints"
+    - "Preparing for research with limited customer access"
+  estimated_time: "15-20 min"
+  intent: >-
+    Guide product managers through preparing for customer discovery interviews by asking adaptive questions about research goals, customer segments, constraints, and methodologies. Use this to design effective
+    interview plans, craft targeted questions, avoid common biases, and maximize learning from limited customer access—ensuring discovery interviews yield actionable insights rather than confirmation bias
+    or surface-level feedback.
+  scenarios:
+    - "I need to interview 5 enterprise customers about why they churned in the last 90 days"
+    - "I'm validating a new product idea with a 2-week deadline and cold outreach only"
+    - "I want to understand why users aren't activating on our core feature"
+  theme: discovery-research
+  type: interactive
 ---
 
 

--- a/skills/discovery-process/SKILL.md
+++ b/skills/discovery-process/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: discovery-process
-argument-hint: "[problem hypothesis]"
 description: Run a full discovery cycle from problem hypothesis to validated solution. Use when a team needs a structured path through framing, interviews, synthesis, and experiments.
-intent: >-
-  Guide product managers through a complete discovery cycle—from initial problem hypothesis to validated solution—by orchestrating problem framing, customer interviews, synthesis, and experimentation skills into a structured process. Use this to systematically explore problem spaces, validate assumptions, and build confidence before committing to full development—avoiding "build it and they will come" syndrome and ensuring you're solving real customer problems.
-type: workflow
-theme: discovery-research
-best_for:
-  - "Running a full discovery cycle from hypothesis to validated solution"
-  - "Investigating a retention or churn problem systematically"
-  - "Setting up continuous discovery as an ongoing practice"
-scenarios:
-  - "I have a hypothesis that B2B customers struggle with onboarding and want to validate it before building anything"
-  - "Our activation rate dropped 15% this quarter and I need to run discovery to find out why"
-estimated_time: "30-60 min"
+compatibility: opencode
+argument-hint: "[problem hypothesis]"
+metadata:
+  best_for:
+    - "Running a full discovery cycle from hypothesis to validated solution"
+    - "Investigating a retention or churn problem systematically"
+    - "Setting up continuous discovery as an ongoing practice"
+  estimated_time: "30-60 min"
+  intent: >-
+    Guide product managers through a complete discovery cycle—from initial problem hypothesis to validated solution—by orchestrating problem framing, customer interviews, synthesis, and experimentation
+    skills into a structured process. Use this to systematically explore problem spaces, validate assumptions, and build confidence before committing to full development—avoiding "build it and they will
+    come" syndrome and ensuring you're solving real customer problems.
+  scenarios:
+    - "I have a hypothesis that B2B customers struggle with onboarding and want to validate it before building anything"
+    - "Our activation rate dropped 15% this quarter and I need to run discovery to find out why"
+  theme: discovery-research
+  type: workflow
 ---
 
 

--- a/skills/eol-message/SKILL.md
+++ b/skills/eol-message/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: eol-message
-argument-hint: "[product or feature being retired]"
 description: Write a clear, empathetic EOL announcement with rationale, customer impact, and next steps. Use when retiring a product, feature, or plan without creating avoidable confusion.
-intent: >-
-  Craft a clear, empathetic End-of-Life (EOL) message that communicates product or feature discontinuation, explains the rationale, addresses customer impact, provides transition support, and positions the replacement solution. Use this to maintain customer trust during difficult transitions and reduce churn by demonstrating care and offering a clear path forward.
-type: component
+compatibility: opencode
+argument-hint: "[product or feature being retired]"
+metadata:
+  intent: >-
+    Craft a clear, empathetic End-of-Life (EOL) message that communicates product or feature discontinuation, explains the rationale, addresses customer impact, provides transition support, and positions
+    the replacement solution. Use this to maintain customer trust during difficult transitions and reduce churn by demonstrating care and offering a clear path forward.
+  type: component
 ---
 
 

--- a/skills/epic-breakdown-advisor/SKILL.md
+++ b/skills/epic-breakdown-advisor/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: epic-breakdown-advisor
-argument-hint: "[epic to split]"
 description: Break down epics into user stories with Humanizing Work split patterns. Use when a backlog item is too large to estimate, sequence, or deliver safely.
-intent: >-
-  Guide product managers through breaking down epics into user stories using Richard Lawrence's complete Humanizing Work methodology—a systematic, flowchart-driven approach that applies 9 splitting patterns sequentially. Use this to identify which pattern applies, split while preserving user value, and evaluate splits based on what they reveal about low-value work you can eliminate. This ensures vertical slicing (end-to-end value) rather than horizontal slicing (technical layers).
-type: interactive
-best_for:
-  - "Splitting epics into smaller vertical slices"
-  - "Choosing the right story split pattern for a large backlog item"
-  - "Turning vague feature blobs into sprint-sized stories"
-scenarios:
-  - "Break this onboarding epic into smaller user stories"
-  - "Help me split a large reporting feature before sprint planning"
-  - "Which story-splitting pattern should I use for this admin workflow epic?"
+compatibility: opencode
+argument-hint: "[epic to split]"
+metadata:
+  best_for:
+    - "Splitting epics into smaller vertical slices"
+    - "Choosing the right story split pattern for a large backlog item"
+    - "Turning vague feature blobs into sprint-sized stories"
+  intent: >-
+    Guide product managers through breaking down epics into user stories using Richard Lawrence's complete Humanizing Work methodology—a systematic, flowchart-driven approach that applies 9 splitting patterns
+    sequentially. Use this to identify which pattern applies, split while preserving user value, and evaluate splits based on what they reveal about low-value work you can eliminate. This ensures vertical
+    slicing (end-to-end value) rather than horizontal slicing (technical layers).
+  scenarios:
+    - "Break this onboarding epic into smaller user stories"
+    - "Help me split a large reporting feature before sprint planning"
+    - "Which story-splitting pattern should I use for this admin workflow epic?"
+  type: interactive
 ---
 
 

--- a/skills/epic-hypothesis/SKILL.md
+++ b/skills/epic-hypothesis/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: epic-hypothesis
-argument-hint: "[initiative or epic idea]"
 description: Frame an epic as a testable hypothesis with target user, expected outcome, and validation method. Use when defining a major initiative before roadmap, discovery, or delivery planning.
-intent: >-
-  Frame epics as testable hypotheses using an if/then structure that articulates the action or solution, the target beneficiary, the expected outcome, and how you'll validate success. Use this to manage uncertainty in product development by making assumptions explicit, defining lightweight experiments ("tiny acts of discovery"), and establishing measurable success criteria before committing to full build-out.
-type: component
+compatibility: opencode
+argument-hint: "[initiative or epic idea]"
+metadata:
+  intent: >-
+    Frame epics as testable hypotheses using an if/then structure that articulates the action or solution, the target beneficiary, the expected outcome, and how you'll validate success. Use this to manage
+    uncertainty in product development by making assumptions explicit, defining lightweight experiments ("tiny acts of discovery"), and establishing measurable success criteria before committing to full
+    build-out.
+  type: component
 ---
 
 

--- a/skills/executive-onboarding-playbook/SKILL.md
+++ b/skills/executive-onboarding-playbook/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: executive-onboarding-playbook
-argument-hint: "[role and company context]"
 description: Plan a VP or CPO 30-60-90 day diagnostic onboarding path. Use when entering a new executive product role and avoiding premature change.
-intent: >-
-  Structure the first 90 days of a VP or CPO transition as a diagnostic process, not an execution sprint. The single most common failure in senior product leadership transitions is acting before understanding — changing structures, replacing people, or announcing strategy before building the evidence base that makes those decisions defensible.
-type: workflow
-theme: career-leadership
-best_for:
-  - "Starting a new VP or CPO role in the first 90 days"
-  - "Evaluating a CPO offer — what to ask before you accept"
-  - "Diagnosing an organization you've just inherited"
-scenarios:
-  - "I just accepted a VP of Product role starting next month — help me plan my first 90 days"
-  - "I'm evaluating a CPO offer and want to know what questions to ask the hiring CEO"
-  - "I'm two months into a new role and want to validate what I've learned before I start acting"
-estimated_time: "20-30 min"
+compatibility: opencode
+argument-hint: "[role and company context]"
+metadata:
+  best_for:
+    - "Starting a new VP or CPO role in the first 90 days"
+    - "Evaluating a CPO offer — what to ask before you accept"
+    - "Diagnosing an organization you've just inherited"
+  estimated_time: "20-30 min"
+  intent: >-
+    Structure the first 90 days of a VP or CPO transition as a diagnostic process, not an execution sprint. The single most common failure in senior product leadership transitions is acting before understanding
+    — changing structures, replacing people, or announcing strategy before building the evidence base that makes those decisions defensible.
+  scenarios:
+    - "I just accepted a VP of Product role starting next month — help me plan my first 90 days"
+    - "I'm evaluating a CPO offer and want to know what questions to ask the hiring CEO"
+    - "I'm two months into a new role and want to validate what I've learned before I start acting"
+  theme: career-leadership
+  type: workflow
 ---
 
 ## Purpose

--- a/skills/feature-investment-advisor/SKILL.md
+++ b/skills/feature-investment-advisor/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: feature-investment-advisor
-argument-hint: "[feature to evaluate]"
 description: Evaluate feature investments using revenue impact, cost structure, ROI, and strategy. Use when deciding whether a feature deserves investment.
-intent: >-
-  Guide product managers through evaluating whether to build a feature based on financial impact analysis. Use this to make data-driven prioritization decisions by assessing revenue connection (direct or indirect), cost structure (dev + COGS + OpEx), ROI calculation, and strategic value—then deliver actionable build/don't build recommendations with supporting math.
-type: interactive
-best_for:
-  - "Assessing whether a feature should be built now"
-  - "Comparing ROI and strategic value of feature ideas"
-  - "Pressure-testing roadmap requests with financial logic"
-scenarios:
-  - "Should we build SSO for mid-market customers this quarter?"
-  - "Evaluate whether an AI assistant feature is worth the investment"
-  - "Help me decide if this roadmap request has enough ROI to build"
+compatibility: opencode
+argument-hint: "[feature to evaluate]"
+metadata:
+  best_for:
+    - "Assessing whether a feature should be built now"
+    - "Comparing ROI and strategic value of feature ideas"
+    - "Pressure-testing roadmap requests with financial logic"
+  intent: >-
+    Guide product managers through evaluating whether to build a feature based on financial impact analysis. Use this to make data-driven prioritization decisions by assessing revenue connection (direct
+    or indirect), cost structure (dev + COGS + OpEx), ROI calculation, and strategic value—then deliver actionable build/don't build recommendations with supporting math.
+  scenarios:
+    - "Should we build SSO for mid-market customers this quarter?"
+    - "Evaluate whether an AI assistant feature is worth the investment"
+    - "Help me decide if this roadmap request has enough ROI to build"
+  type: interactive
 ---
 
 

--- a/skills/finance-based-pricing-advisor/SKILL.md
+++ b/skills/finance-based-pricing-advisor/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: finance-based-pricing-advisor
-argument-hint: "[pricing change to evaluate]"
 description: Evaluate pricing changes using ARPU, conversion, churn risk, NRR, and payback. Use when deciding whether a pricing move should ship.
-intent: >-
-  Evaluate the **financial impact** of pricing changes (price increases, new tiers, add-ons, discounts) using ARPU/ARPA analysis, conversion impact, churn risk, NRR effects, and CAC payback implications. Use this to make data-driven go/no-go decisions on proposed pricing changes with supporting math and risk assessment.
-type: interactive
-best_for:
-  - "Evaluating price increases, discounts, or new packaging"
-  - "Estimating churn and conversion risk before a pricing change"
-  - "Making a go/no-go call on monetization changes"
-scenarios:
-  - "Should we raise prices 15% for new customers next quarter?"
-  - "Evaluate a new premium tier for our SaaS product"
-  - "Help me assess whether an annual discount will improve revenue"
+compatibility: opencode
+argument-hint: "[pricing change to evaluate]"
+metadata:
+  best_for:
+    - "Evaluating price increases, discounts, or new packaging"
+    - "Estimating churn and conversion risk before a pricing change"
+    - "Making a go/no-go call on monetization changes"
+  intent: >-
+    Evaluate the **financial impact** of pricing changes (price increases, new tiers, add-ons, discounts) using ARPU/ARPA analysis, conversion impact, churn risk, NRR effects, and CAC payback implications.
+    Use this to make data-driven go/no-go decisions on proposed pricing changes with supporting math and risk assessment.
+  scenarios:
+    - "Should we raise prices 15% for new customers next quarter?"
+    - "Evaluate a new premium tier for our SaaS product"
+    - "Help me assess whether an annual discount will improve revenue"
+  type: interactive
 ---
 
 

--- a/skills/finance-metrics-quickref/SKILL.md
+++ b/skills/finance-metrics-quickref/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: finance-metrics-quickref
-argument-hint: "[metric name]"
 description: Look up SaaS finance metrics, formulas, and benchmarks fast. Use when you need a quick metric definition, formula, or benchmark during analysis.
-intent: >-
-  Quick reference for any SaaS finance metric without deep teaching. Use this when you need a fast formula lookup, benchmark check, or decision framework reminder. For detailed explanations, calculations, and examples, see the related deep-dive skills.
-type: component
-best_for:
-  - "Quick metric lookups during product or finance reviews"
-  - "Checking formulas and benchmarks without reading a long explainer"
-  - "Refreshing decision rules for common SaaS metrics"
-scenarios:
-  - "What is the formula for NRR and what is a good benchmark?"
-  - "Give me a quick reference for CAC payback and Rule of 40"
-  - "I need a fast SaaS metrics cheat sheet for a business review"
+compatibility: opencode
+argument-hint: "[metric name]"
+metadata:
+  best_for:
+    - "Quick metric lookups during product or finance reviews"
+    - "Checking formulas and benchmarks without reading a long explainer"
+    - "Refreshing decision rules for common SaaS metrics"
+  intent: >-
+    Quick reference for any SaaS finance metric without deep teaching. Use this when you need a fast formula lookup, benchmark check, or decision framework reminder. For detailed explanations, calculations,
+    and examples, see the related deep-dive skills.
+  scenarios:
+    - "What is the formula for NRR and what is a good benchmark?"
+    - "Give me a quick reference for CAC payback and Rule of 40"
+    - "I need a fast SaaS metrics cheat sheet for a business review"
+  type: component
 ---
 
 

--- a/skills/jobs-to-be-done/SKILL.md
+++ b/skills/jobs-to-be-done/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: jobs-to-be-done
-argument-hint: "[customer segment or product]"
 description: Uncover customer jobs, pains, and gains in a structured JTBD format. Use when clarifying unmet needs, repositioning a product, or improving discovery and messaging.
-intent: >-
-  Systematically explore what customers are trying to accomplish (functional, social, emotional jobs), the pains they experience, and the gains they seek. Use this framework to uncover unmet needs, validate product ideas, and ensure your solution addresses real motivations—not just surface-level feature requests.
-type: component
+compatibility: opencode
+argument-hint: "[customer segment or product]"
+metadata:
+  intent: >-
+    Systematically explore what customers are trying to accomplish (functional, social, emotional jobs), the pains they experience, and the gains they seek. Use this framework to uncover unmet needs, validate
+    product ideas, and ensure your solution addresses real motivations—not just surface-level feature requests.
+  type: component
 ---
 
 

--- a/skills/lean-ux-canvas/SKILL.md
+++ b/skills/lean-ux-canvas/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: lean-ux-canvas
-argument-hint: "[business problem]"
 description: Guide teams through Lean UX Canvas v2. Use when framing a business problem, surfacing assumptions, and defining what to learn next.
-intent: >-
-  Guide product managers through creating **Jeff Gothelf's Lean UX Canvas (v2)**—a one-page facilitation tool that frames work around a **business problem to solve**, not a **solution to implement**. Use this to align cross-functional teams around core assumptions, craft testable hypotheses, and ensure learning happens every sprint by exposing gaps in understanding (problem, users, value, and why the solution should work).
-type: interactive
-best_for:
-  - "Framing a business problem before solutioning"
-  - "Surfacing assumptions in a cross-functional workshop"
-  - "Turning a vague initiative into hypotheses and learning goals"
-scenarios:
-  - "Help me run a Lean UX Canvas workshop for onboarding drop-off"
-  - "Use Lean UX Canvas to frame a new AI product idea"
-  - "We have a business problem but too many assumptions. Run a Lean UX Canvas session."
+compatibility: opencode
+argument-hint: "[business problem]"
+metadata:
+  best_for:
+    - "Framing a business problem before solutioning"
+    - "Surfacing assumptions in a cross-functional workshop"
+    - "Turning a vague initiative into hypotheses and learning goals"
+  intent: >-
+    Guide product managers through creating **Jeff Gothelf's Lean UX Canvas (v2)**—a one-page facilitation tool that frames work around a **business problem to solve**, not a **solution to implement**.
+    Use this to align cross-functional teams around core assumptions, craft testable hypotheses, and ensure learning happens every sprint by exposing gaps in understanding (problem, users, value, and why
+    the solution should work).
+  scenarios:
+    - "Help me run a Lean UX Canvas workshop for onboarding drop-off"
+    - "Use Lean UX Canvas to frame a new AI product idea"
+    - "We have a business problem but too many assumptions. Run a Lean UX Canvas session."
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/opportunity-solution-tree/SKILL.md
+++ b/skills/opportunity-solution-tree/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: opportunity-solution-tree
-argument-hint: "[stakeholder request or outcome]"
 description: Build an Opportunity Solution Tree from outcomes to opportunities, solutions, and tests. Use when a stakeholder request needs problem framing before you decide what to build.
-intent: >-
-  Guide product managers through creating an Opportunity Solution Tree (OST) by extracting target outcomes from stakeholder requests, generating opportunity options (problems to solve), mapping potential solutions, and selecting the best proof-of-concept (POC) based on feasibility, impact, and market fit. Use this to move from vague product requests to structured discovery, ensuring teams solve the right problems before jumping to solutions—avoiding "feature factory" syndrome and premature convergence on ideas.
-type: interactive
+compatibility: opencode
+argument-hint: "[stakeholder request or outcome]"
+metadata:
+  intent: >-
+    Guide product managers through creating an Opportunity Solution Tree (OST) by extracting target outcomes from stakeholder requests, generating opportunity options (problems to solve), mapping potential
+    solutions, and selecting the best proof-of-concept (POC) based on feasibility, impact, and market fit. Use this to move from vague product requests to structured discovery, ensuring teams solve the
+    right problems before jumping to solutions—avoiding "feature factory" syndrome and premature convergence on ideas.
+  type: interactive
 ---
 
 

--- a/skills/organic-growth-advisor/SKILL.md
+++ b/skills/organic-growth-advisor/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: organic-growth-advisor
+description: "Identify which organic growth path to pursue — new segments, geographies, channels, or products. Use when diagnosing where a growth constraint lives and which McKinsey growth level to act\
+  \ on next."
+compatibility: opencode
 argument-hint: "[product and growth context]"
-description: "Identify which organic growth path to pursue — new segments, geographies, channels, or products. Use when diagnosing where a growth constraint lives and which McKinsey growth level to act on next."
-intent: >-
-  Guide product managers through a fast triage to identify which of four organic growth paths fits their current constraint: new customer segments (L2), new geographies (L3), new distribution channels (L4), or new products or services (L5). Uses a 2x2 diagnostic based on customer/market context familiarity and degree of product change required. Outputs a growth path recommendation with rationale and immediate next steps.
-type: interactive
-best_for:
-  - "Choosing which organic growth motion to pursue when multiple seem viable"
-  - "Diagnosing whether the constraint is in reach, access, market context, or product value"
-  - "Setting up an AI-assisted growth experiment with the right starting hypothesis"
-scenarios:
-  - "We need to grow but aren't sure if we should go after new customer segments or new geographies"
-  - "Help me figure out which McKinsey growth level we should focus on"
-  - "We have strong product-market fit but growth is stalling. Where should we look?"
-  - "Which organic growth path fits our current situation?"
+metadata:
+  best_for:
+    - "Choosing which organic growth motion to pursue when multiple seem viable"
+    - "Diagnosing whether the constraint is in reach, access, market context, or product value"
+    - "Setting up an AI-assisted growth experiment with the right starting hypothesis"
+  intent: >-
+    Guide product managers through a fast triage to identify which of four organic growth paths fits their current constraint: new customer segments (L2), new geographies (L3), new distribution channels
+    (L4), or new products or services (L5). Uses a 2x2 diagnostic based on customer/market context familiarity and degree of product change required. Outputs a growth path recommendation with rationale
+    and immediate next steps.
+  scenarios:
+    - "We need to grow but aren't sure if we should go after new customer segments or new geographies"
+    - "Help me figure out which McKinsey growth level we should focus on"
+    - "We have strong product-market fit but growth is stalling. Where should we look?"
+    - "Which organic growth path fits our current situation?"
+  type: interactive
 ---
 
 

--- a/skills/pestel-analysis/SKILL.md
+++ b/skills/pestel-analysis/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: pestel-analysis
-argument-hint: "[product or market]"
 description: Analyze political, economic, social, technological, environmental, and legal forces. Use when external market shifts could materially affect a product, roadmap, or strategy.
-intent: >-
-  Conduct a systematic analysis of macro-environmental factors—Political, Economic, Social, Technological, Environmental, and Legal—that could impact your product or project. Use this to identify external opportunities and threats, inform strategic planning, assess market entry risks, and make data-driven decisions about product direction in the context of broader forces beyond your control.
-type: component
+compatibility: opencode
+argument-hint: "[product or market]"
+metadata:
+  intent: >-
+    Conduct a systematic analysis of macro-environmental factors—Political, Economic, Social, Technological, Environmental, and Legal—that could impact your product or project. Use this to identify external
+    opportunities and threats, inform strategic planning, assess market entry risks, and make data-driven decisions about product direction in the context of broader forces beyond your control.
+  type: component
 ---
 
 

--- a/skills/pm-skill-creator/SKILL.md
+++ b/skills/pm-skill-creator/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: pm-skill-creator
-argument-hint: "[idea or raw content]"
 description: Design a new PM skill through guided conversation. Use when you have raw content or an idea and want to shape it into a compliant skill.
-intent: >-
-  Walk through the full skill design process interactively — from raw idea or content to a structured, repo-compliant SKILL.md draft. Asks adaptive questions to determine skill type, scope, structure, and content, then generates a ready-to-validate draft.
-type: interactive
-theme: meta-authoring
-best_for:
-  - "Turning a rough idea or framework into a structured PM skill"
-  - "Deciding whether raw content should be a component, interactive, or workflow skill"
-  - "Getting from blank page to a complete SKILL.md draft through guided conversation"
-scenarios:
-  - "I have notes from a workshop and want to turn them into a skill"
-  - "Help me create a new skill — I know the topic but not the structure"
-  - "I have a PM framework I want to formalize as a repo skill"
-estimated_time: "10-15 min"
+compatibility: opencode
+argument-hint: "[idea or raw content]"
+metadata:
+  best_for:
+    - "Turning a rough idea or framework into a structured PM skill"
+    - "Deciding whether raw content should be a component, interactive, or workflow skill"
+    - "Getting from blank page to a complete SKILL.md draft through guided conversation"
+  estimated_time: "10-15 min"
+  intent: >-
+    Walk through the full skill design process interactively — from raw idea or content to a structured, repo-compliant SKILL.md draft. Asks adaptive questions to determine skill type, scope, structure,
+    and content, then generates a ready-to-validate draft.
+  scenarios:
+    - "I have notes from a workshop and want to turn them into a skill"
+    - "Help me create a new skill — I know the topic but not the structure"
+    - "I have a PM framework I want to formalize as a repo skill"
+  theme: meta-authoring
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/pol-probe-advisor/SKILL.md
+++ b/skills/pol-probe-advisor/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: pol-probe-advisor
-argument-hint: "[hypothesis or risk]"
 description: Select the right Proof of Life (PoL) probe based on hypothesis, risk, and resources. Use this to match the validation method to the real learning goal, not tooling comfort.
-intent: >-
-  Guide product managers through selecting the right **Proof of Life (PoL) probe** type (of 5 flavors) based on their hypothesis, risk, and available resources. Use this when you need to eliminate a specific risk or test a narrow hypothesis, but aren't sure which validation method to use. This interactive skill ensures you match the cheapest prototype to the harshest truth—not the prototype you're most comfortable building.
-type: interactive
-best_for:
-  - "Choosing the cheapest useful validation method for a risky idea"
-  - "Matching a hypothesis to the right Proof of Life probe"
-  - "Avoiding overbuilding before learning the harsh truth"
-scenarios:
-  - "Which Proof of Life probe should I use to test demand for this idea?"
-  - "Help me pick the right validation method for an onboarding hypothesis"
-  - "I have a risky AI concept. What PoL probe should I run first?"
+compatibility: opencode
+argument-hint: "[hypothesis or risk]"
+metadata:
+  best_for:
+    - "Choosing the cheapest useful validation method for a risky idea"
+    - "Matching a hypothesis to the right Proof of Life probe"
+    - "Avoiding overbuilding before learning the harsh truth"
+  intent: >-
+    Guide product managers through selecting the right **Proof of Life (PoL) probe** type (of 5 flavors) based on their hypothesis, risk, and available resources. Use this when you need to eliminate a specific
+    risk or test a narrow hypothesis, but aren't sure which validation method to use. This interactive skill ensures you match the cheapest prototype to the harshest truth—not the prototype you're most
+    comfortable building.
+  scenarios:
+    - "Which Proof of Life probe should I use to test demand for this idea?"
+    - "Help me pick the right validation method for an onboarding hypothesis"
+    - "I have a risky AI concept. What PoL probe should I run first?"
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/pol-probe/SKILL.md
+++ b/skills/pol-probe/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: pol-probe
-argument-hint: "[hypothesis to test]"
 description: Define a Proof of Life probe to test a risky hypothesis cheaply. Use when you need harsh truth before building real product.
-intent: >-
-  Define and document a **Proof of Life (PoL) probe**—a lightweight, disposable validation artifact designed to surface harsh truths before expensive development. Use this when you need to eliminate a specific risk or test a narrow hypothesis **without building production-quality software**. PoL probes are reconnaissance missions, not MVPs—they're meant to be deleted, not scaled.
-type: component
-best_for:
-  - "Documenting a lightweight validation artifact before build"
-  - "Testing a narrow hypothesis without shipping production software"
-  - "Reducing risk before spending engineering time"
-scenarios:
-  - "Define a Proof of Life probe for a new workflow automation idea"
-  - "Help me write a PoL probe for this pricing hypothesis"
-  - "Create a low-cost validation probe before we build this feature"
+compatibility: opencode
+argument-hint: "[hypothesis to test]"
+metadata:
+  best_for:
+    - "Documenting a lightweight validation artifact before build"
+    - "Testing a narrow hypothesis without shipping production software"
+    - "Reducing risk before spending engineering time"
+  intent: >-
+    Define and document a **Proof of Life (PoL) probe**—a lightweight, disposable validation artifact designed to surface harsh truths before expensive development. Use this when you need to eliminate a
+    specific risk or test a narrow hypothesis **without building production-quality software**. PoL probes are reconnaissance missions, not MVPs—they're meant to be deleted, not scaled.
+  scenarios:
+    - "Define a Proof of Life probe for a new workflow automation idea"
+    - "Help me write a PoL probe for this pricing hypothesis"
+    - "Create a low-cost validation probe before we build this feature"
+  type: component
 ---
 
 ## Purpose

--- a/skills/positioning-statement/SKILL.md
+++ b/skills/positioning-statement/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: positioning-statement
-argument-hint: "[product] [target customer]"
 description: Create a Geoffrey Moore-style positioning statement. Use when clarifying who you serve, what problem you solve, your category, and why you're different from alternatives.
-intent: >-
-  Create a Geoffrey Moore-style positioning statement that clearly articulates who your product serves, what need it addresses, how it's categorized, what benefit it delivers, and how it differs from alternatives. Use this when you need to align stakeholders on product strategy, guide messaging, or test if your value proposition is crisp and defensible.
-type: component
-theme: strategy-positioning
-best_for:
-  - "Defining your product's market position clearly for the first time"
-  - "Differentiating from specific competitors in your messaging"
-  - "Aligning your team on who you serve, what problem you solve, and why you're different"
-scenarios:
-  - "I need to write a positioning statement for a new B2B SaaS product targeting mid-market HR teams"
-  - "Our positioning feels generic and I need to sharpen it against two specific competitors"
-estimated_time: "10-15 min"
+compatibility: opencode
+argument-hint: "[product] [target customer]"
+metadata:
+  best_for:
+    - "Defining your product's market position clearly for the first time"
+    - "Differentiating from specific competitors in your messaging"
+    - "Aligning your team on who you serve, what problem you solve, and why you're different"
+  estimated_time: "10-15 min"
+  intent: >-
+    Create a Geoffrey Moore-style positioning statement that clearly articulates who your product serves, what need it addresses, how it's categorized, what benefit it delivers, and how it differs from
+    alternatives. Use this when you need to align stakeholders on product strategy, guide messaging, or test if your value proposition is crisp and defensible.
+  scenarios:
+    - "I need to write a positioning statement for a new B2B SaaS product targeting mid-market HR teams"
+    - "Our positioning feels generic and I need to sharpen it against two specific competitors"
+  theme: strategy-positioning
+  type: component
 ---
 
 

--- a/skills/positioning-workshop/SKILL.md
+++ b/skills/positioning-workshop/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: positioning-workshop
-argument-hint: "[product]"
 description: Run a positioning workshop that surfaces target customer, unmet need, category, benefits, and differentiation. Use when your product messaging feels fuzzy, generic, or misaligned.
-intent: >-
-  Guide product managers through discovering and articulating product positioning by asking adaptive questions about target customers, unmet needs, product category, benefits, and competitive differentiation. Use this to align stakeholders on strategic positioning before writing PRDs, launch plans, or marketing materials—ensuring you've made deliberate choices about who you serve, what need you address, and how you differ from alternatives.
-type: interactive
-best_for:
-  - "Running a workshop to sharpen product positioning"
-  - "Clarifying target customer, category, and differentiation"
-  - "Fixing fuzzy or generic messaging before launch"
-scenarios:
-  - "Help me run a positioning workshop for our B2B analytics product"
-  - "Our messaging feels generic. Facilitate a positioning session."
-  - "We need to define who we serve and why we're different"
+compatibility: opencode
+argument-hint: "[product]"
+metadata:
+  best_for:
+    - "Running a workshop to sharpen product positioning"
+    - "Clarifying target customer, category, and differentiation"
+    - "Fixing fuzzy or generic messaging before launch"
+  intent: >-
+    Guide product managers through discovering and articulating product positioning by asking adaptive questions about target customers, unmet needs, product category, benefits, and competitive differentiation.
+    Use this to align stakeholders on strategic positioning before writing PRDs, launch plans, or marketing materials—ensuring you've made deliberate choices about who you serve, what need you address,
+    and how you differ from alternatives.
+  scenarios:
+    - "Help me run a positioning workshop for our B2B analytics product"
+    - "Our messaging feels generic. Facilitate a positioning session."
+    - "We need to define who we serve and why we're different"
+  type: interactive
 ---
 
 

--- a/skills/prd-development/SKILL.md
+++ b/skills/prd-development/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: prd-development
-argument-hint: "[feature or initiative]"
 description: Build a structured PRD that connects problem, users, solution, and success criteria. Use when turning discovery notes into an engineering-ready document for a major initiative.
-intent: >-
-  Guide product managers through structured PRD (Product Requirements Document) creation by orchestrating problem framing, user research synthesis, solution definition, and success criteria into a cohesive document. Use this to move from scattered notes and Slack threads to a clear, comprehensive PRD that aligns stakeholders, provides engineering context, and serves as a source of truth—avoiding ambiguity, scope creep, and the "build what's in my head" trap.
-type: workflow
-theme: pm-artifacts
-best_for:
-  - "Writing a complete PRD from scratch"
-  - "Structuring product requirements for an engineering handoff"
-  - "Documenting a major new feature before development begins"
-scenarios:
-  - "I need a PRD for a new AI-powered recommendation feature in our e-commerce platform"
-  - "I've completed a discovery sprint and need to turn the findings into a PRD my engineers can act on"
-estimated_time: "60-120 min"
+compatibility: opencode
+argument-hint: "[feature or initiative]"
+metadata:
+  best_for:
+    - "Writing a complete PRD from scratch"
+    - "Structuring product requirements for an engineering handoff"
+    - "Documenting a major new feature before development begins"
+  estimated_time: "60-120 min"
+  intent: >-
+    Guide product managers through structured PRD (Product Requirements Document) creation by orchestrating problem framing, user research synthesis, solution definition, and success criteria into a cohesive
+    document. Use this to move from scattered notes and Slack threads to a clear, comprehensive PRD that aligns stakeholders, provides engineering context, and serves as a source of truth—avoiding ambiguity,
+    scope creep, and the "build what's in my head" trap.
+  scenarios:
+    - "I need a PRD for a new AI-powered recommendation feature in our e-commerce platform"
+    - "I've completed a discovery sprint and need to turn the findings into a PRD my engineers can act on"
+  theme: pm-artifacts
+  type: workflow
 ---
 
 

--- a/skills/press-release/SKILL.md
+++ b/skills/press-release/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: press-release
-argument-hint: "[product or feature idea]"
 description: Write an Amazon-style press release that defines customer value before building. Use when aligning stakeholders on a new product, feature, or strategic bet.
-intent: >-
-  Create a visionary press release following Amazon's "Working Backwards" methodology to define and communicate a product or feature before building it. Use this to align stakeholders on the customer value proposition, clarify the problem being solved, and test if the product story resonates—treating the press release as a forcing function for clarity and customer-centricity.
-type: component
+compatibility: opencode
+argument-hint: "[product or feature idea]"
+metadata:
+  intent: >-
+    Create a visionary press release following Amazon's "Working Backwards" methodology to define and communicate a product or feature before building it. Use this to align stakeholders on the customer
+    value proposition, clarify the problem being solved, and test if the product story resonates—treating the press release as a forcing function for clarity and customer-centricity.
+  type: component
 ---
 
 

--- a/skills/prioritization-advisor/SKILL.md
+++ b/skills/prioritization-advisor/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: prioritization-advisor
-argument-hint: "[decision context]"
 description: Choose a prioritization framework based on stage, team context, and stakeholder needs. Use when deciding between RICE, ICE, value/effort, or another scoring approach.
-intent: >-
-  Guide product managers in choosing the right prioritization framework by asking adaptive questions about product stage, team context, decision-making needs, and stakeholder dynamics. Use this to avoid "framework whiplash" (switching frameworks constantly) or applying the wrong framework (e.g., using RICE for strategic bets or ICE for data-driven decisions). Outputs a recommended framework with implementation guidance tailored to your context.
-type: interactive
-best_for:
-  - "Choosing the right prioritization framework for a team or stage"
-  - "Deciding between RICE, ICE, value/effort, and similar models"
-  - "Reducing debate about how to prioritize competing work"
-scenarios:
-  - "Which prioritization framework should my startup use right now?"
-  - "Help me choose between RICE and value/effort for roadmap planning"
-  - "We keep arguing about prioritization. Recommend a framework."
+compatibility: opencode
+argument-hint: "[decision context]"
+metadata:
+  best_for:
+    - "Choosing the right prioritization framework for a team or stage"
+    - "Deciding between RICE, ICE, value/effort, and similar models"
+    - "Reducing debate about how to prioritize competing work"
+  intent: >-
+    Guide product managers in choosing the right prioritization framework by asking adaptive questions about product stage, team context, decision-making needs, and stakeholder dynamics. Use this to avoid
+    "framework whiplash" (switching frameworks constantly) or applying the wrong framework (e.g., using RICE for strategic bets or ICE for data-driven decisions). Outputs a recommended framework with implementation
+    guidance tailored to your context.
+  scenarios:
+    - "Which prioritization framework should my startup use right now?"
+    - "Help me choose between RICE and value/effort for roadmap planning"
+    - "We keep arguing about prioritization. Recommend a framework."
+  type: interactive
 ---
 
 

--- a/skills/problem-framing-canvas/SKILL.md
+++ b/skills/problem-framing-canvas/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: problem-framing-canvas
-argument-hint: "[problem area]"
 description: Guide teams through MITRE's Problem Framing Canvas. Use when you need a clearer problem statement before jumping to solutions.
-intent: >-
-  Guide product managers through the MITRE Problem Framing Canvas process by asking structured questions across three phases: Look Inward (examine your own assumptions and biases), Look Outward (understand who experiences the problem and who doesn't), and Reframe (synthesize insights into an actionable problem statement and "How Might We" question). Use this to ensure you're solving the right problem before jumping to solutions—avoiding confirmation bias, overlooked stakeholders, and solution-first thinking.
-type: interactive
-best_for:
-  - "Clarifying a messy problem before solutioning"
-  - "Surfacing assumptions and overlooked stakeholders"
-  - "Creating a bias-resistant problem statement in a workshop"
-scenarios:
-  - "Run a Problem Framing Canvas for our mobile retention issue"
-  - "Help me reframe this stakeholder request before we build anything"
-  - "We need a clearer problem statement for onboarding drop-off"
+compatibility: opencode
+argument-hint: "[problem area]"
+metadata:
+  best_for:
+    - "Clarifying a messy problem before solutioning"
+    - "Surfacing assumptions and overlooked stakeholders"
+    - "Creating a bias-resistant problem statement in a workshop"
+  intent: >-
+    Guide product managers through the MITRE Problem Framing Canvas process by asking structured questions across three phases: Look Inward (examine your own assumptions and biases), Look Outward (understand
+    who experiences the problem and who doesn't), and Reframe (synthesize insights into an actionable problem statement and "How Might We" question). Use this to ensure you're solving the right problem
+    before jumping to solutions—avoiding confirmation bias, overlooked stakeholders, and solution-first thinking.
+  scenarios:
+    - "Run a Problem Framing Canvas for our mobile retention issue"
+    - "Help me reframe this stakeholder request before we build anything"
+    - "We need a clearer problem statement for onboarding drop-off"
+  type: interactive
 ---
 
 

--- a/skills/problem-statement/SKILL.md
+++ b/skills/problem-statement/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: problem-statement
-argument-hint: "[user and their struggle]"
 description: Write a user-centered problem statement with who is blocked, what they are trying to do, why it matters, and how it feels. Use when framing discovery, prioritization, or a PRD.
-intent: >-
-  Articulate a problem from the user's perspective using an empathy-driven framework that captures who they are, what they're trying to do, what's blocking them, why, and how it makes them feel. Use this to align stakeholders on the problem before jumping to solutions, and to frame product work around user outcomes rather than feature requests.
-type: component
+compatibility: opencode
+argument-hint: "[user and their struggle]"
+metadata:
+  intent: >-
+    Articulate a problem from the user's perspective using an empathy-driven framework that captures who they are, what they're trying to do, what's blocking them, why, and how it makes them feel. Use this
+    to align stakeholders on the problem before jumping to solutions, and to frame product work around user outcomes rather than feature requests.
+  type: component
 ---
 
 

--- a/skills/product-sense-interview-answer/SKILL.md
+++ b/skills/product-sense-interview-answer/SKILL.md
@@ -1,24 +1,26 @@
 ---
 name: product-sense-interview-answer
-argument-hint: "[interview prompt]"
 description: Structure a spoken PM product-sense answer with assumptions, segmentation, pain-point prioritization, and MVP tradeoffs. Use when practicing design, improve, or build-next interview questions.
-intent: >-
-  Coach PM candidates through open-ended product-sense interviews using a repeatable
-  six-part answer spine: clarify, rationale, goal, segmentation, pain points,
-  and solution choice. Use this to practice product design and product improvement
-  questions, avoid solution-first answers, and produce responses that sound
-  thoughtful out loud rather than over-scripted on the page.
-type: component
-theme: career-leadership
-best_for:
-  - "Practicing product design and product improvement interview questions"
-  - "Coaching candidates who jump to solutions too quickly"
-  - "Turning messy ideation into a crisp spoken interview answer"
-scenarios:
-  - "How would you improve YouTube?"
-  - "Design a product for travelers with flight anxiety"
-  - "What would you build next for DoorDash?"
-estimated_time: "20-30 min"
+compatibility: opencode
+argument-hint: "[interview prompt]"
+metadata:
+  best_for:
+    - "Practicing product design and product improvement interview questions"
+    - "Coaching candidates who jump to solutions too quickly"
+    - "Turning messy ideation into a crisp spoken interview answer"
+  estimated_time: "20-30 min"
+  intent: >-
+    Coach PM candidates through open-ended product-sense interviews using a repeatable
+    six-part answer spine: clarify, rationale, goal, segmentation, pain points,
+    and solution choice. Use this to practice product design and product improvement
+    questions, avoid solution-first answers, and produce responses that sound
+    thoughtful out loud rather than over-scripted on the page.
+  scenarios:
+    - "How would you improve YouTube?"
+    - "Design a product for travelers with flight anxiety"
+    - "What would you build next for DoorDash?"
+  theme: career-leadership
+  type: component
 ---
 
 ## Purpose

--- a/skills/product-strategy-session/SKILL.md
+++ b/skills/product-strategy-session/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: product-strategy-session
-argument-hint: "[product or strategic question]"
 description: Run an end-to-end product strategy session across positioning, discovery, and roadmap planning. Use when a team needs validated direction before committing to execution.
-intent: >-
-  Guide product managers through a comprehensive product strategy session by orchestrating positioning, problem framing, customer discovery, and roadmap planning skills into a cohesive end-to-end process. Use this to move from vague strategic direction to concrete, validated product strategy with clear positioning, target customers, problem statements, and prioritized roadmap—ensuring alignment across stakeholders before committing to execution.
-type: workflow
+compatibility: opencode
+argument-hint: "[product or strategic question]"
+metadata:
+  intent: >-
+    Guide product managers through a comprehensive product strategy session by orchestrating positioning, problem framing, customer discovery, and roadmap planning skills into a cohesive end-to-end process.
+    Use this to move from vague strategic direction to concrete, validated product strategy with clear positioning, target customers, problem statements, and prioritized roadmap—ensuring alignment across
+    stakeholders before committing to execution.
+  type: workflow
 ---
 
 

--- a/skills/proto-persona/SKILL.md
+++ b/skills/proto-persona/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: proto-persona
-argument-hint: "[target user or segment]"
 description: Create a proto-persona from current research, market signals, and team knowledge. Use when you need a working customer profile before deeper validation.
-intent: >-
-  Create an initial, assumption-based persona profile that synthesizes available user research, market data, and stakeholder knowledge into a working hypothesis about your target user. Use this to align teams early in product development, guide initial design decisions, and identify gaps in understanding that require validation through research.
-type: component
+compatibility: opencode
+argument-hint: "[target user or segment]"
+metadata:
+  intent: >-
+    Create an initial, assumption-based persona profile that synthesizes available user research, market data, and stakeholder knowledge into a working hypothesis about your target user. Use this to align
+    teams early in product development, guide initial design decisions, and identify gaps in understanding that require validation through research.
+  type: component
 ---
 
 

--- a/skills/recommendation-canvas/SKILL.md
+++ b/skills/recommendation-canvas/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: recommendation-canvas
-argument-hint: "[AI product idea]"
 description: Evaluate an AI product idea across outcomes, hypotheses, risks, and positioning. Use when deciding whether an AI solution deserves investment or recommendation.
-intent: >-
-  Evaluate and propose AI product solutions using a structured canvas that assesses business outcomes, customer outcomes, problem framing, solution hypotheses, positioning, risks, and value justification. Use this to build a comprehensive, defensible recommendation for stakeholders and decision-makers—especially when proposing AI-powered features or products that carry higher uncertainty and risk.
-type: component
+compatibility: opencode
+argument-hint: "[AI product idea]"
+metadata:
+  intent: >-
+    Evaluate and propose AI product solutions using a structured canvas that assesses business outcomes, customer outcomes, problem framing, solution hypotheses, positioning, risks, and value justification.
+    Use this to build a comprehensive, defensible recommendation for stakeholders and decision-makers—especially when proposing AI-powered features or products that carry higher uncertainty and risk.
+  type: component
 ---
 
 

--- a/skills/roadmap-planning/SKILL.md
+++ b/skills/roadmap-planning/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: roadmap-planning
-argument-hint: "[product and planning horizon]"
 description: Plan a strategic roadmap across prioritization, epic definition, stakeholder alignment, and sequencing. Use when turning strategy into a release plan that teams can execute.
-intent: >-
-  Guide product managers through strategic roadmap planning by orchestrating prioritization, epic definition, stakeholder alignment, and release sequencing skills into a structured process. Use this to move from disconnected feature requests to a cohesive, outcome-driven roadmap that aligns stakeholders, sequences work logically, and communicates strategic intent—avoiding "feature factory" roadmaps that lack strategic narrative or customer-centric framing.
-type: workflow
-theme: strategy-positioning
-best_for:
-  - "Building a strategic roadmap that survives exec review"
-  - "Prioritizing competing initiatives across multiple teams"
-  - "Planning and sequencing work for the next quarter or half-year"
-scenarios:
-  - "I have 15 competing initiatives and need to build a Q2 roadmap my exec team will actually approve"
-  - "I'm planning our 6-month product roadmap and need to sequence work across 3 teams"
-estimated_time: "45-90 min"
+compatibility: opencode
+argument-hint: "[product and planning horizon]"
+metadata:
+  best_for:
+    - "Building a strategic roadmap that survives exec review"
+    - "Prioritizing competing initiatives across multiple teams"
+    - "Planning and sequencing work for the next quarter or half-year"
+  estimated_time: "45-90 min"
+  intent: >-
+    Guide product managers through strategic roadmap planning by orchestrating prioritization, epic definition, stakeholder alignment, and release sequencing skills into a structured process. Use this to
+    move from disconnected feature requests to a cohesive, outcome-driven roadmap that aligns stakeholders, sequences work logically, and communicates strategic intent—avoiding "feature factory" roadmaps
+    that lack strategic narrative or customer-centric framing.
+  scenarios:
+    - "I have 15 competing initiatives and need to build a Q2 roadmap my exec team will actually approve"
+    - "I'm planning our 6-month product roadmap and need to sequence work across 3 teams"
+  theme: strategy-positioning
+  type: workflow
 ---
 
 

--- a/skills/saas-economics-efficiency-metrics/SKILL.md
+++ b/skills/saas-economics-efficiency-metrics/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: saas-economics-efficiency-metrics
-argument-hint: "[metrics or question]"
 description: Evaluate SaaS unit economics and capital efficiency. Use when deciding whether the business can scale efficiently or needs correction.
-intent: >-
-  Determine whether your SaaS business model is fundamentally viable and capital-efficient. Use this to calculate unit economics, assess profitability, manage cash runway, and decide when to scale vs. optimize. Essential for fundraising, board reporting, and making smart investment trade-offs.
-type: component
-best_for:
-  - "Checking whether a SaaS model is financially viable"
-  - "Reviewing CAC, LTV, payback, burn, and Rule of 40 together"
-  - "Preparing efficiency analysis for a board or leadership review"
-scenarios:
-  - "Evaluate our SaaS unit economics before we scale paid acquisition"
-  - "Help me analyze CAC payback, LTV, and burn for our product"
-  - "I need a SaaS efficiency check for our board deck"
+compatibility: opencode
+argument-hint: "[metrics or question]"
+metadata:
+  best_for:
+    - "Checking whether a SaaS model is financially viable"
+    - "Reviewing CAC, LTV, payback, burn, and Rule of 40 together"
+    - "Preparing efficiency analysis for a board or leadership review"
+  intent: >-
+    Determine whether your SaaS business model is fundamentally viable and capital-efficient. Use this to calculate unit economics, assess profitability, manage cash runway, and decide when to scale vs.
+    optimize. Essential for fundraising, board reporting, and making smart investment trade-offs.
+  scenarios:
+    - "Evaluate our SaaS unit economics before we scale paid acquisition"
+    - "Help me analyze CAC payback, LTV, and burn for our product"
+    - "I need a SaaS efficiency check for our board deck"
+  type: component
 ---
 
 

--- a/skills/saas-revenue-growth-metrics/SKILL.md
+++ b/skills/saas-revenue-growth-metrics/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: saas-revenue-growth-metrics
-argument-hint: "[metrics or question]"
 description: Calculate SaaS revenue, retention, and growth metrics. Use when diagnosing momentum, churn, expansion, or product-market-fit signals.
-intent: >-
-  Master revenue and retention metrics to understand SaaS business momentum, evaluate product-market fit, and make data-driven decisions about growth investments. Use this to calculate key metrics, interpret trends, identify problems early, and communicate business health to stakeholders.
-type: component
-theme: finance-metrics
-best_for:
-  - "Understanding your key revenue and retention metrics"
-  - "Calculating MRR, ARR, churn, and NRR correctly"
-  - "Building a metrics dashboard for your SaaS product"
-scenarios:
-  - "I need to calculate and interpret our MRR, churn rate, and NRR for a board deck"
-  - "Help me understand the difference between gross and net revenue retention and how to improve it"
-estimated_time: "10-15 min"
+compatibility: opencode
+argument-hint: "[metrics or question]"
+metadata:
+  best_for:
+    - "Understanding your key revenue and retention metrics"
+    - "Calculating MRR, ARR, churn, and NRR correctly"
+    - "Building a metrics dashboard for your SaaS product"
+  estimated_time: "10-15 min"
+  intent: >-
+    Master revenue and retention metrics to understand SaaS business momentum, evaluate product-market fit, and make data-driven decisions about growth investments. Use this to calculate key metrics, interpret
+    trends, identify problems early, and communicate business health to stakeholders.
+  scenarios:
+    - "I need to calculate and interpret our MRR, churn rate, and NRR for a board deck"
+    - "Help me understand the difference between gross and net revenue retention and how to improve it"
+  theme: finance-metrics
+  type: component
 ---
 
 

--- a/skills/skill-authoring-workflow/SKILL.md
+++ b/skills/skill-authoring-workflow/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: skill-authoring-workflow
-argument-hint: "[source content or skill to update]"
 description: Turn raw PM content into a compliant, publish-ready skill. Use when creating or updating a repo skill without breaking standards.
-intent: >-
-  Create or update PM skills without chaos. This workflow turns rough notes, workshop content, or half-baked prompt dumps into compliant `skills/<skill-name>/SKILL.md` assets that actually pass validation and belong in this repo.
-type: workflow
-best_for:
-  - "Creating a new repo skill from notes or source material"
-  - "Updating an existing skill while keeping standards intact"
-  - "Running the full authoring and validation workflow before commit"
-scenarios:
-  - "Help me turn these workshop notes into a new PM skill"
-  - "I need to update an existing skill without breaking the repo standards"
-  - "What workflow should I use to author a new skill in this repo?"
+compatibility: opencode
+argument-hint: "[source content or skill to update]"
+metadata:
+  best_for:
+    - "Creating a new repo skill from notes or source material"
+    - "Updating an existing skill while keeping standards intact"
+    - "Running the full authoring and validation workflow before commit"
+  intent: >-
+    Create or update PM skills without chaos. This workflow turns rough notes, workshop content, or half-baked prompt dumps into compliant `skills/<skill-name>/SKILL.md` assets that actually pass validation
+    and belong in this repo.
+  scenarios:
+    - "Help me turn these workshop notes into a new PM skill"
+    - "I need to update an existing skill without breaking the repo standards"
+    - "What workflow should I use to author a new skill in this repo?"
+  type: workflow
 ---
 
 ## Purpose

--- a/skills/stakeholder-engagement-advisor/SKILL.md
+++ b/skills/stakeholder-engagement-advisor/SKILL.md
@@ -1,29 +1,31 @@
 ---
 name: stakeholder-engagement-advisor
-argument-hint: "[stakeholder and situation]"
 description: Plan engagement for a specific stakeholder. Use when preparing an outreach, navigating resistance, or aligning a critical relationship before a key milestone.
-intent: >-
-  Guide per-stakeholder engagement planning through the Adaptive Decision Ladder:
-  three targeted questions diagnose the stakeholder's profile, power/impact quadrant,
-  and your engagement context, then deliver a tailored approach — key message framing,
-  recommended medium and cadence, what you need from them versus what they need from
-  you, and a named next action with owner and deadline. Treats both sides of the
-  relationship, not just yours.
-type: interactive
-best_for:
-  - "Preparing to engage a powerful executive sponsor whose support is critical but whose motivations are unclear"
-  - "Planning outreach to a resistant or skeptical stakeholder who could block your roadmap"
-  - "Navigating first contact with a newly identified stakeholder mid-initiative"
-  - "Designing inclusive engagement for a Q1 (high-impact, low-power) user community that needs more voice"
-  - "Aligning cross-functional engagement strategy before a high-stakes roadmap review or launch"
-scenarios:
-  - "Help me plan how to engage [stakeholder] before my roadmap review"
-  - "I have a resistant stakeholder — how do I approach them?"
-  - "I need to bring a new executive sponsor up to speed quickly"
-  - "How do I engage frontline users who've been excluded from our feedback loops?"
-  - "Help me prepare a 1:1 with someone who could block this initiative"
-sources:
-  - "MITRE Innovation Toolkit — Quickstart Stakeholder Engagement Canvas: https://itk.mitre.org/toolkit-tools/quickstart-stakeholder-engagement-canvas/"
+compatibility: opencode
+argument-hint: "[stakeholder and situation]"
+metadata:
+  best_for:
+    - "Preparing to engage a powerful executive sponsor whose support is critical but whose motivations are unclear"
+    - "Planning outreach to a resistant or skeptical stakeholder who could block your roadmap"
+    - "Navigating first contact with a newly identified stakeholder mid-initiative"
+    - "Designing inclusive engagement for a Q1 (high-impact, low-power) user community that needs more voice"
+    - "Aligning cross-functional engagement strategy before a high-stakes roadmap review or launch"
+  intent: >-
+    Guide per-stakeholder engagement planning through the Adaptive Decision Ladder:
+    three targeted questions diagnose the stakeholder's profile, power/impact quadrant,
+    and your engagement context, then deliver a tailored approach — key message framing,
+    recommended medium and cadence, what you need from them versus what they need from
+    you, and a named next action with owner and deadline. Treats both sides of the
+    relationship, not just yours.
+  scenarios:
+    - "Help me plan how to engage [stakeholder] before my roadmap review"
+    - "I have a resistant stakeholder — how do I approach them?"
+    - "I need to bring a new executive sponsor up to speed quickly"
+    - "How do I engage frontline users who've been excluded from our feedback loops?"
+    - "Help me prepare a 1:1 with someone who could block this initiative"
+  sources:
+    - "MITRE Innovation Toolkit — Quickstart Stakeholder Engagement Canvas: https://itk.mitre.org/toolkit-tools/quickstart-stakeholder-engagement-canvas/"
+  type: interactive
 ---
 
 # Stakeholder Engagement Advisor

--- a/skills/stakeholder-identification/SKILL.md
+++ b/skills/stakeholder-identification/SKILL.md
@@ -1,28 +1,30 @@
 ---
 name: stakeholder-identification
-argument-hint: "[initiative]"
 description: Map every stakeholder before engaging anyone. Use when launching an initiative, scoping discovery, or building an engagement plan from scratch.
-intent: >-
-  Produce a comprehensive, equity-aware stakeholder set before any engagement begins.
-  Combines broad brainstorm with structured categorization (Allies / Audiences / Influencers,
-  R/P/D marking), an explicit equity and bias check, and a disciplined narrowing to
-  the 2-3 stakeholders to understand deeply first. Designed to run as a solo exercise
-  or a kickoff workshop. Feed outputs directly into stakeholder-mapping for prioritization.
-type: component
-best_for:
-  - "Launching a new initiative where the stakeholder landscape is unmapped and influence networks are unknown"
-  - "Scoping a discovery sprint to define who to research, interview, and recruit"
-  - "Preparing a PRD stakeholder section with a validated, comprehensive list before writing requirements"
-  - "Onboarding to a new product domain and needing to map allies, gatekeepers, and decision-makers quickly"
-  - "Pressure-testing an existing stakeholder list for blind spots, bias, and missing edge-case populations"
-scenarios:
-  - "Who are all the stakeholders for this initiative?"
-  - "Are we missing anyone important in our stakeholder map?"
-  - "Help me prepare the stakeholder section of my PRD"
-  - "Who should we recruit for discovery research?"
-sources:
-  - "MITRE Innovation Toolkit — Stakeholder Identification Canvas: https://itk.mitre.org/toolkit-tools/stakeholder-identification-canvas/"
-  - "MITRE Innovation Toolkit — Community Map: https://itk.mitre.org/toolkit-tools/community-map/"
+compatibility: opencode
+argument-hint: "[initiative]"
+metadata:
+  best_for:
+    - "Launching a new initiative where the stakeholder landscape is unmapped and influence networks are unknown"
+    - "Scoping a discovery sprint to define who to research, interview, and recruit"
+    - "Preparing a PRD stakeholder section with a validated, comprehensive list before writing requirements"
+    - "Onboarding to a new product domain and needing to map allies, gatekeepers, and decision-makers quickly"
+    - "Pressure-testing an existing stakeholder list for blind spots, bias, and missing edge-case populations"
+  intent: >-
+    Produce a comprehensive, equity-aware stakeholder set before any engagement begins.
+    Combines broad brainstorm with structured categorization (Allies / Audiences / Influencers,
+    R/P/D marking), an explicit equity and bias check, and a disciplined narrowing to
+    the 2-3 stakeholders to understand deeply first. Designed to run as a solo exercise
+    or a kickoff workshop. Feed outputs directly into stakeholder-mapping for prioritization.
+  scenarios:
+    - "Who are all the stakeholders for this initiative?"
+    - "Are we missing anyone important in our stakeholder map?"
+    - "Help me prepare the stakeholder section of my PRD"
+    - "Who should we recruit for discovery research?"
+  sources:
+    - "MITRE Innovation Toolkit — Stakeholder Identification Canvas: https://itk.mitre.org/toolkit-tools/stakeholder-identification-canvas/"
+    - "MITRE Innovation Toolkit — Community Map: https://itk.mitre.org/toolkit-tools/community-map/"
+  type: component
 ---
 
 # Stakeholder Identification

--- a/skills/stakeholder-mapping/SKILL.md
+++ b/skills/stakeholder-mapping/SKILL.md
@@ -1,29 +1,31 @@
 ---
 name: stakeholder-mapping
-argument-hint: "[stakeholder list or initiative]"
 description: Prioritize stakeholders using two complementary grids. Use when setting engagement strategy and surfacing whose voice needs elevating after stakeholder identification.
-intent: >-
-  Run two complementary 2x2 grids — Power × Interest (sets engagement strategy per
-  stakeholder) and Impact × Power (surfaces who bears consequences but lacks voice) —
-  then compare outputs to reveal blind spots and plan quadrant migration. The grids
-  answer different questions and neither one alone is sufficient: Power × Interest
-  tells you how to engage; Impact × Power tells you whose voice to elevate. Feed
-  outputs into stakeholder-engagement-advisor for per-stakeholder action planning.
-type: component
-best_for:
-  - "After stakeholder identification, when you need to decide who gets which level of engagement"
-  - "Preparing an engagement plan before a roadmap review where executives and impacted user groups have conflicting authority"
-  - "Surfacing high-impact, low-power user segments who deserve more voice in product decisions but lack org pull"
-  - "Re-baselining stakeholder strategy after a reorg has shifted who holds decision authority"
-  - "Planning a compliance or regulatory initiative where power to block sits separately from who bears the consequences"
-scenarios:
-  - "Who should I prioritize engaging on this initiative?"
-  - "How do I handle stakeholders with conflicting priorities?"
-  - "Help me figure out whose voice is missing from our roadmap decisions"
-  - "I need a stakeholder engagement strategy before our quarterly review"
-sources:
-  - "MITRE Innovation Toolkit — Stakeholder Map & Matrix: https://itk.mitre.org/toolkit-tools/stakeholder-map-and-matrix/"
-  - "MITRE Innovation Toolkit — Stakeholder Power Categories: https://itk.mitre.org/toolkit-tools/stakeholder-power-categories/"
+compatibility: opencode
+argument-hint: "[stakeholder list or initiative]"
+metadata:
+  best_for:
+    - "After stakeholder identification, when you need to decide who gets which level of engagement"
+    - "Preparing an engagement plan before a roadmap review where executives and impacted user groups have conflicting authority"
+    - "Surfacing high-impact, low-power user segments who deserve more voice in product decisions but lack org pull"
+    - "Re-baselining stakeholder strategy after a reorg has shifted who holds decision authority"
+    - "Planning a compliance or regulatory initiative where power to block sits separately from who bears the consequences"
+  intent: >-
+    Run two complementary 2x2 grids — Power × Interest (sets engagement strategy per
+    stakeholder) and Impact × Power (surfaces who bears consequences but lacks voice) —
+    then compare outputs to reveal blind spots and plan quadrant migration. The grids
+    answer different questions and neither one alone is sufficient: Power × Interest
+    tells you how to engage; Impact × Power tells you whose voice to elevate. Feed
+    outputs into stakeholder-engagement-advisor for per-stakeholder action planning.
+  scenarios:
+    - "Who should I prioritize engaging on this initiative?"
+    - "How do I handle stakeholders with conflicting priorities?"
+    - "Help me figure out whose voice is missing from our roadmap decisions"
+    - "I need a stakeholder engagement strategy before our quarterly review"
+  sources:
+    - "MITRE Innovation Toolkit — Stakeholder Map & Matrix: https://itk.mitre.org/toolkit-tools/stakeholder-map-and-matrix/"
+    - "MITRE Innovation Toolkit — Stakeholder Power Categories: https://itk.mitre.org/toolkit-tools/stakeholder-power-categories/"
+  type: component
 ---
 
 # Stakeholder Mapping

--- a/skills/storyboard/SKILL.md
+++ b/skills/storyboard/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: storyboard
-argument-hint: "[user and problem]"
 description: Create a six-frame storyboard that shows a user's journey from problem to solution. Use when you need a fast narrative for alignment, concept reviews, or demos.
-intent: >-
-  Create a 6-frame visual narrative that tells the story of a user's journey from problem to solution, using the classic storytelling arc to build empathy, illustrate value, and make abstract product concepts concrete. Use this to align stakeholders, pitch features, communicate vision, or test if your solution resonates emotionally before building it.
-type: component
+compatibility: opencode
+argument-hint: "[user and problem]"
+metadata:
+  intent: >-
+    Create a 6-frame visual narrative that tells the story of a user's journey from problem to solution, using the classic storytelling arc to build empathy, illustrate value, and make abstract product
+    concepts concrete. Use this to align stakeholders, pitch features, communicate vision, or test if your solution resonates emotionally before building it.
+  type: component
 ---
 
 

--- a/skills/tam-sam-som-calculator/SKILL.md
+++ b/skills/tam-sam-som-calculator/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: tam-sam-som-calculator
-argument-hint: "[product idea] [market constraints]"
 description: Calculate TAM, SAM, and SOM with explicit assumptions, methods, and caveats. Use when sizing a market for a product idea, business case, or executive review.
-intent: >-
-  Guide product managers through calculating Total Addressable Market (TAM), Serviceable Available Market (SAM), and Serviceable Obtainable Market (SOM) for a product idea by asking adaptive, contextually relevant questions. Use this to build defensible market size estimates backed by real-world citations, economic projections, and population data—essential for pitching to investors, securing budget, or validating product-market fit.
-type: interactive
+compatibility: opencode
+argument-hint: "[product idea] [market constraints]"
+metadata:
+  intent: >-
+    Guide product managers through calculating Total Addressable Market (TAM), Serviceable Available Market (SAM), and Serviceable Obtainable Market (SOM) for a product idea by asking adaptive, contextually
+    relevant questions. Use this to build defensible market size estimates backed by real-world citations, economic projections, and population data—essential for pitching to investors, securing budget,
+    or validating product-market fit.
+  type: interactive
 ---
 
 

--- a/skills/user-story-mapping-workshop/SKILL.md
+++ b/skills/user-story-mapping-workshop/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: user-story-mapping-workshop
-argument-hint: "[system or workflow]"
 description: Run a user story mapping workshop with adaptive questions and a structured map output. Use when you need backbone activities, tasks, and release slices for a workflow.
-intent: >-
-  Guide product managers through creating a user story map by asking adaptive questions about the system, users, workflow, and priorities—then generating a two-dimensional map with backbone (activities), user tasks, and release slices. Use this to move from flat backlogs to visual story maps that communicate the big picture, identify missing functionality, and enable meaningful release planning—avoiding "context-free mulch" where stories lose connection to the overall system narrative.
-type: interactive
+compatibility: opencode
+argument-hint: "[system or workflow]"
+metadata:
+  intent: >-
+    Guide product managers through creating a user story map by asking adaptive questions about the system, users, workflow, and priorities—then generating a two-dimensional map with backbone (activities),
+    user tasks, and release slices. Use this to move from flat backlogs to visual story maps that communicate the big picture, identify missing functionality, and enable meaningful release planning—avoiding
+    "context-free mulch" where stories lose connection to the overall system narrative.
+  type: interactive
 ---
 
 

--- a/skills/user-story-mapping/SKILL.md
+++ b/skills/user-story-mapping/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: user-story-mapping
-argument-hint: "[product or workflow]"
 description: Create a user story map that lays out activities, steps, tasks, and release slices. Use when planning a workflow, backlog, or MVP around the user journey.
-intent: >-
-  Visualize the user journey by creating a hierarchical map that breaks down high-level activities into steps and tasks, organized left-to-right as a narrative flow. Use this to build shared understanding across product, design, and engineering, prioritize features based on user workflows, and identify gaps or opportunities in the user experience.
-type: component
+compatibility: opencode
+argument-hint: "[product or workflow]"
+metadata:
+  intent: >-
+    Visualize the user journey by creating a hierarchical map that breaks down high-level activities into steps and tasks, organized left-to-right as a narrative flow. Use this to build shared understanding
+    across product, design, and engineering, prioritize features based on user workflows, and identify gaps or opportunities in the user experience.
+  type: component
 ---
 
 

--- a/skills/user-story-splitting/SKILL.md
+++ b/skills/user-story-splitting/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: user-story-splitting
-argument-hint: "[story or epic to split]"
 description: Break a large story or epic into smaller deliverable stories using proven split patterns. Use when backlog items are too big for estimation, sequencing, or independent release.
-intent: >-
-  Break down large user stories, epics, or features into smaller, independently deliverable stories using systematic splitting patterns. Use this to make work more manageable, reduce risk, enable faster feedback cycles, and maintain flow in agile development. This skill applies to user stories, epics, and any work that's too large to complete in a single sprint.
-type: component
+compatibility: opencode
+argument-hint: "[story or epic to split]"
+metadata:
+  intent: >-
+    Break down large user stories, epics, or features into smaller, independently deliverable stories using systematic splitting patterns. Use this to make work more manageable, reduce risk, enable faster
+    feedback cycles, and maintain flow in agile development. This skill applies to user stories, epics, and any work that's too large to complete in a single sprint.
+  type: component
 ---
 
 

--- a/skills/user-story/SKILL.md
+++ b/skills/user-story/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: user-story
-argument-hint: "[feature or user need]"
 description: Create user stories with Mike Cohn format and Gherkin acceptance criteria. Use when turning user needs into development-ready work with clear outcomes and testable conditions.
-intent: >-
-  Create clear, concise user stories that combine Mike Cohn's user story format with Gherkin-style acceptance criteria. Use this to translate user needs into actionable development work that focuses on outcomes, ensures shared understanding between product and engineering, and provides testable success criteria.
-type: component
-theme: pm-artifacts
-best_for:
-  - "Writing user stories with proper acceptance criteria"
-  - "Converting requirements into development-ready stories"
-  - "Establishing story quality standards across your team"
-scenarios:
-  - "I need to write a user story for a new notification system in our B2B SaaS app"
-  - "Convert this PRD requirement into a properly formatted user story with Gherkin acceptance criteria"
-estimated_time: "5-10 min"
+compatibility: opencode
+argument-hint: "[feature or user need]"
+metadata:
+  best_for:
+    - "Writing user stories with proper acceptance criteria"
+    - "Converting requirements into development-ready stories"
+    - "Establishing story quality standards across your team"
+  estimated_time: "5-10 min"
+  intent: >-
+    Create clear, concise user stories that combine Mike Cohn's user story format with Gherkin-style acceptance criteria. Use this to translate user needs into actionable development work that focuses on
+    outcomes, ensures shared understanding between product and engineering, and provides testable success criteria.
+  scenarios:
+    - "I need to write a user story for a new notification system in our B2B SaaS app"
+    - "Convert this PRD requirement into a properly formatted user story with Gherkin acceptance criteria"
+  theme: pm-artifacts
+  type: component
 ---
 
 

--- a/skills/vp-cpo-readiness-advisor/SKILL.md
+++ b/skills/vp-cpo-readiness-advisor/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: vp-cpo-readiness-advisor
-argument-hint: "[where you are in the transition]"
 description: Guide the transition to VP or CPO across preparing, interviewing, landing, and recalibrating. Use when executive product scope is changing fast.
-intent: >-
-  Guide Directors and senior product leaders through the specific challenges of the transition to VP or CPO using adaptive questions and targeted coaching. Diagnoses where you are in the journey and delivers practical, lived-experience coaching calibrated to your situation — not generic executive advice.
-type: interactive
-theme: career-leadership
-best_for:
-  - "Preparing for the Director-to-VP or VP-to-CPO transition"
-  - "Evaluating a VP or CPO role before you accept it"
-  - "Recalibrating when something isn't working in an executive product role"
-scenarios:
-  - "I'm a Director preparing for VP roles and want to understand what actually changes"
-  - "I have a CPO offer I'm evaluating — what are the right questions to ask the CEO?"
-  - "I've been a VP for 18 months and my executive peer relationships aren't working"
-estimated_time: "15-20 min"
+compatibility: opencode
+argument-hint: "[where you are in the transition]"
+metadata:
+  best_for:
+    - "Preparing for the Director-to-VP or VP-to-CPO transition"
+    - "Evaluating a VP or CPO role before you accept it"
+    - "Recalibrating when something isn't working in an executive product role"
+  estimated_time: "15-20 min"
+  intent: >-
+    Guide Directors and senior product leaders through the specific challenges of the transition to VP or CPO using adaptive questions and targeted coaching. Diagnoses where you are in the journey and delivers
+    practical, lived-experience coaching calibrated to your situation — not generic executive advice.
+  scenarios:
+    - "I'm a Director preparing for VP roles and want to understand what actually changes"
+    - "I have a CPO offer I'm evaluating — what are the right questions to ask the CEO?"
+    - "I've been a VP for 18 months and my executive peer relationships aren't working"
+  theme: career-leadership
+  type: interactive
 ---
 
 ## Purpose

--- a/skills/workshop-facilitation/SKILL.md
+++ b/skills/workshop-facilitation/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: workshop-facilitation
 description: Facilitate workshop sessions in a one-step, multi-turn flow. Use when an interactive skill needs consistent pacing, options, and progress tracking.
-intent: >-
-  Provide the canonical facilitation pattern for interactive skills: one step at a time, with clear progress, adaptive recommendations at decision points, and predictable interruption handling.
-type: interactive
-theme: workshops-facilitation
-best_for:
-  - "Adding structured facilitation to any PM workshop or guided session"
-  - "Running interactive sessions with numbered recommendations and progress tracking"
-  - "Ensuring your workshops stay on track and end with actionable choices"
-scenarios:
-  - "I want to run a structured positioning workshop with my product team — set up the facilitation protocol"
-  - "Help me facilitate a discovery sprint kickoff with clear questions, options, and progress labels"
-estimated_time: "varies by workshop"
+compatibility: opencode
+metadata:
+  best_for:
+    - "Adding structured facilitation to any PM workshop or guided session"
+    - "Running interactive sessions with numbered recommendations and progress tracking"
+    - "Ensuring your workshops stay on track and end with actionable choices"
+  estimated_time: "varies by workshop"
+  intent: >-
+    Provide the canonical facilitation pattern for interactive skills: one step at a time, with clear progress, adaptive recommendations at decision points, and predictable interruption handling.
+  scenarios:
+    - "I want to run a structured positioning workshop with my product team — set up the facilitation protocol"
+    - "Help me facilitate a discovery sprint kickoff with clear questions, options, and progress labels"
+  theme: workshops-facilitation
+  type: interactive
 ---
 
 ## Purpose


### PR DESCRIPTION
Closes: #19

## What this PR does

Adds OpenCode runtime compatibility to all 55 Product Manager skills:

1. **Adds `compatibility: opencode`** to every SKILL.md frontmatter. OpenCode recognizes this field for discovery optimization. No functional impact on other runtimes (Claude Code, Cursor, n8n ignore unknown fields).

2. **Nests rich fields under `metadata:`** to align with OpenCode's frontmatter schema. Fields moved: `intent`, `type`, `theme`, `best_for`, `scenarios`, `estimated_time`, `sources`. OpenCode agents can read these at runtime; the `skill` tool indexes `name` and `description` for matching.

3. **Preserves `argument-hint`** as a top-level field — Claude Code autocomplete depends on it, and OpenCode harmlessly ignores unknown fields.

4. **Adds install instructions for OpenCode** in README.md, START_HERE.md, and docs/INSTALL-OPENCODE.md: copy to `~/.config/opencode/skills/` (global) or `.opencode/skills/` (project).

5. **Updates `scripts/check-skill-metadata.py`** to search `metadata` fallback for `intent` and `type` — standard fields that moved under `metadata:`.

## Example change

**Before** (prd-development SKILL.md):
```yaml
---
name: prd-development
argument-hint: "[feature or initiative]"
description: Build a structured PRD...
intent: >-
  Guide product managers...
type: workflow
theme: pm-artifacts
best_for:
  - "Writing a complete..."
scenarios:
  - "I need a PRD for..."
estimated_time: "60-120 min"
---
```

**After**:
```yaml
---
name: prd-development
description: Build a structured PRD...
compatibility: opencode
argument-hint: "[feature or initiative]"
metadata:
  intent: >-
    Guide product managers...
  type: workflow
  theme: pm-artifacts
  best_for:
    - "Writing a complete..."
  scenarios:
    - "I need a PRD for..."
  estimated_time: "60-120 min"
---
```

## Validation
- `scripts/check-skill-metadata.py` passes on all 55 skills
- No skill body content changed — only frontmatter
- No runtime-specific syntax introduced (consistent with CONTRIBUTING.md philosophy)
- Skills continue to work identically on existing runtimes (Claude Code, Cursor, Codex, n8n) — they ignore unknown frontmatter fields

## Cross-references
- OpenCode docs on agent skills: https://opencode.ai/docs/skills/
- OpenCode discovers `.claude/skills/` natively — install docs are optional, just documented here