### PR TITLE
docs: remove missing transcript inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,6 @@
   - [`director-readiness-advisor`](skills/director-readiness-advisor/SKILL.md) (Interactive) — Coaching across four situations: preparing, interviewing, newly landed, recalibrating. Based on E42
   - [`executive-onboarding-playbook`](skills/executive-onboarding-playbook/SKILL.md) (Workflow) — 30-60-90 day diagnostic playbook for VP/CPO transitions. Based on [E43](https://the-product-porch-43ca35c0.simplecast.com/episodes/becoming-a-vp-cpo-leading-product-at-the-executive-level-part-2)
   - [`vp-cpo-readiness-advisor`](skills/vp-cpo-readiness-advisor/SKILL.md) (Interactive) — Director→VP/CPO coaching; includes CEO interview framework. Based on E43
-- **Source transcripts:** `research/product_porch_transcript.making-the-shift-from-pm-to-director-of-product.md` and `research/product_porch_transcript.becoming-a-vp-or-cpo-of-product-at-executive-level.md`
 - **Potential follow-on:** VP/CPO→C-suite transition (separate skill set, not yet sourced)
 
 **Phase 6: AI PM Orchestrator Skills (In Progress)**


### PR DESCRIPTION
## Summary

Remove the two absent local Product Porch transcript paths while retaining the canonical episode links already attached to the four released skills.

## Validation

The local transcript files are absent at the pinned repository snapshot, the canonical episode links remain, the patch passes `git apply --check`, and `CLAUDE.md` has zero broken bindings under attest.

This docs-only correction was found with the attest static instruction-binding scan.